### PR TITLE
Fix extension check

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3,13 +3,20 @@ use std::fs;
 
 fn main() {
     let args: Vec<String> = env::args().collect();
+
+    if args.len() < 2 {
+        eprintln!("Usage: {} <rom.gb|rom.gbc>", args[0]);
+        return;
+    }
+
     let file_path = &args[1];
 
-    if !file_path.ends_with(".gb") || !file_path.ends_with(".gbc") {
+    if !file_path.ends_with(".gb") && !file_path.ends_with(".gbc") {
         println!("File must be a .gb or .gbc file");
         return;
     }
 
-    let contents = fs::read_to_string(file_path).expect("Something went wrong reading the file");
+    let contents = fs::read_to_string(file_path)
+        .expect("Something went wrong reading the file");
     println!("with text:\n{}", contents);
 }


### PR DESCRIPTION
## Summary
- check for missing command line arguments
- fix file extension check to properly require `.gb` or `.gbc`

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6841a0b9c89083328c9e10574b531129