### PR TITLE
Phase 1でカートリッジとBus基盤を実装し、Phase 2の土台を整える

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,8 +1,22 @@
-github_actions:
-  - ".github/**/*.yml"
+# 'docs' フォルダ内またはそのサブフォルダ内の変更に 'Documentation' ラベルを追加
 documentation:
-  - "**/*.md"
-  - "docs/**/*"
-  - "website/**/*"
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'docs/**'
+          - '**/*.md'
+
+# Cargo系ファイルに変更があった場合、'dependencies' ラベルを追加
 dependencies:
-  - "**/go.mod"
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/Cargo.toml"
+          - "**/Cargo.lock"
+
+# 'src' フォルダ内またはそのサブフォルダ内の変更に 'enhancement' ラベルを追加
+enhancement:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/**/*.rs"
+          - ".github/**/*.yml"
+  - head-branch: [ '^feature', 'feature' ]
+

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -11,6 +11,7 @@ jobs:
     steps:
     - uses: actions/first-interaction@v3
       with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        issue-message: "Thanks **#** first issue, plz wait for owner comments"
-        pr-message: "Thanks **#** first pull request, plz wait for owner comments"
+        issue_message: |
+          Thanks **#** first issue, plz wait for owner comments
+        pr_message: |
+          Thanks **#** first pull request, plz wait for owner comments

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -47,3 +47,19 @@ jobs:
 
       - name: Run tests
         run: cargo test --verbose
+
+      - name: Verify ROM loading
+        run: |
+          cargo build
+          failed=0
+          while read -r rom; do
+            echo "Verifying $rom..."
+            if ! ./target/debug/game_girl "$rom"; then
+              echo "Error: Failed to load $rom"
+              failed=$((failed + 1))
+            fi
+          done < <(find roms -name "*.gb" -o -name "*.gbc")
+          if [ $failed -ne 0 ]; then
+            echo "$failed ROMs failed to load"
+            exit 1
+          fi

--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -18,11 +18,11 @@ GameGirl must execute DMG Game Boy ROMs accurately enough that behavior is drive
 - ✓ CLI entry point accepts a ROM path argument and rejects paths without `.gb` or `.gbc` suffixes — existing
 - ✓ Project includes local validation ROM suites for future emulator tests — existing
 - ✓ Project includes DMG-focused implementation research and a subsystem roadmap — existing
+- ✓ Load cartridge files as binary data and parse enough header metadata to identify the ROM and initial cartridge behavior — Phase 1
+- ✓ Define a DMG memory bus with 16-bit addressing and 8-bit read/write access — Phase 1
 
 ### Active
 
-- [ ] Load cartridge files as binary data and parse enough header metadata to identify the ROM and initial cartridge behavior
-- [ ] Define a DMG memory bus with 16-bit addressing and 8-bit read/write access
 - [ ] Start execution from documented post-boot DMG state rather than emulating the Nintendo boot ROM in v1.0
 - [ ] Implement CPU register state, instruction fetch/decode/execute flow, flags, stack behavior, and staged core instruction groups
 - [ ] Capture minimal serial output from `FF01`/`FF02` so ROM fixtures can report test results early
@@ -41,7 +41,7 @@ GameGirl must execute DMG Game Boy ROMs accurately enough that behavior is drive
 
 ## Context
 
-- The codebase is an early Rust CLI prototype. `src/main.rs` currently reads the supplied ROM path as UTF-8 text, so cartridge loading must switch to byte-oriented file reads before real ROM execution.
+- The codebase now has a thin CLI plus reusable `cartridge` and `bus` modules. Phase 2 should build CPU fetch/decode/execute through the Bus from documented post-boot state.
 - `docs/hot_to_proceed.md` recommends a Bus-centered design with CPU, PPU, Timer, Joypad, and Cartridge decoupled behind memory access.
 - `docs/gameboy_architecture_summary.md` narrows the initial target to DMG behavior, including the 16-bit memory map, LR35902/SM83 register model, interrupt priority, timer edge behavior, PPU modes, and VRAM/OAM access constraints.
 - The repository includes blargg and mooneye ROM suites under `roms/`, which should become the backbone for regression checks.
@@ -62,8 +62,8 @@ GameGirl must execute DMG Game Boy ROMs accurately enough that behavior is drive
 |----------|-----------|---------|
 | Map the brownfield codebase before initialization | Existing code and docs should define validated context instead of treating the repo as blank | ✓ Good |
 | Target DMG behavior first | The docs and available tests support a focused first emulator target, while CGB multiplies hardware variance | — Pending |
-| Build around a Bus abstraction | CPU-visible memory behavior spans cartridge, RAM, timer, PPU, joypad, interrupts, and later audio | — Pending |
-| Replace text ROM loading with byte loading before emulator work | Game Boy ROMs are binary files and the current UTF-8 path is only a placeholder | — Pending |
+| Build around a Bus abstraction | CPU-visible memory behavior spans cartridge, RAM, timer, PPU, joypad, interrupts, and later audio | ✓ Phase 1 |
+| Replace text ROM loading with byte loading before emulator work | Game Boy ROMs are binary files and the current UTF-8 path is only a placeholder | ✓ Phase 1 |
 | Use blargg/mooneye ROMs for milestone validation | Emulator correctness depends on edge cases that ordinary demos can miss | — Pending |
 | Insert a minimal serial ROM harness before timer/interrupt work | CPU changes should encounter ROM-style failures early instead of waiting for a broad validation phase | — Pending |
 | Skip Nintendo boot ROM emulation in v1.0 | Starting at documented post-boot DMG state keeps the first milestone focused and aligns CPU defaults around `PC = 0x0100` | — Pending |
@@ -86,4 +86,4 @@ This document evolves at phase transitions and milestone boundaries.
 4. Update Context with current state
 
 ---
-*Last updated: 2026-05-02 after roadmap feedback insertion*
+*Last updated: 2026-05-02 after Phase 1 completion*

--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -1,0 +1,84 @@
+# GameGirl
+
+## What This Is
+
+GameGirl is a Rust Game Boy emulator project. The repository currently contains a minimal CLI scaffold, implementation notes, Game Boy hardware research, and a substantial local ROM corpus for future validation.
+
+The immediate product direction is a DMG-first emulator core that can load real `.gb` ROM bytes, model the CPU/bus/devices accurately enough to run test ROMs, and grow toward rendering, input, cartridges, and audio in deliberate phases.
+
+## Core Value
+
+GameGirl must execute DMG Game Boy ROMs accurately enough that behavior is driven by hardware rules and verified by known test ROMs, not by ad hoc demo success.
+
+## Requirements
+
+### Validated
+
+- ✓ Rust binary crate exists with Cargo metadata — existing
+- ✓ CLI entry point accepts a ROM path argument and rejects paths without `.gb` or `.gbc` suffixes — existing
+- ✓ Project includes local validation ROM suites for future emulator tests — existing
+- ✓ Project includes DMG-focused implementation research and a subsystem roadmap — existing
+
+### Active
+
+- [ ] Load cartridge files as binary data and parse enough header metadata to identify the ROM and initial cartridge behavior
+- [ ] Define a DMG memory bus with 16-bit addressing and 8-bit read/write access
+- [ ] Implement CPU register state, instruction fetch/decode/execute flow, flags, stack behavior, and core instruction groups
+- [ ] Add timer and interrupt state using hardware-oriented timing rules, including delayed interrupt enable behavior
+- [ ] Introduce PPU mode timing and VRAM/OAM access restrictions before full rendering
+- [ ] Run automated checks against local blargg and mooneye ROM fixtures as emulator capabilities appear
+
+### Out of Scope
+
+- CGB-specific behavior — defer until a DMG core is stable
+- Full audio output — defer until CPU, bus, timer, interrupts, PPU timing, and basic cartridge execution are grounded
+- Polished desktop UI — defer until the emulator core can run meaningful ROMs
+- Broad MBC coverage beyond the first cartridge path — start with the simplest supported cartridge behavior before expanding
+- Cycle-perfect edge cases everywhere in the first milestone — capture architecture that can support precision, then tighten with tests
+
+## Context
+
+- The codebase is an early Rust CLI prototype. `src/main.rs` currently reads the supplied ROM path as UTF-8 text, so cartridge loading must switch to byte-oriented file reads before real ROM execution.
+- `docs/hot_to_proceed.md` recommends a Bus-centered design with CPU, PPU, Timer, Joypad, and Cartridge decoupled behind memory access.
+- `docs/gameboy_architecture_summary.md` narrows the initial target to DMG behavior, including the 16-bit memory map, LR35902/SM83 register model, interrupt priority, timer edge behavior, PPU modes, and VRAM/OAM access constraints.
+- The repository includes blargg and mooneye ROM suites under `roms/`, which should become the backbone for regression checks.
+- The local codebase map is in `.planning/codebase/` and should be used before planning implementation phases.
+
+## Constraints
+
+- **Tech stack**: Rust 2021 with Cargo — match the existing crate and avoid adding dependencies unless they remove real implementation risk.
+- **Compatibility**: DMG-first — keep Color Game Boy behavior out of the initial critical path.
+- **Correctness**: Use test ROMs as a decision aid when documentation and intuition disagree.
+- **Architecture**: Keep CPU, bus, cartridge, timer, PPU, joypad, and eventual APU responsibilities separated so hardware timing rules can be tested in isolation.
+- **Input data**: ROMs are untrusted binary files — cartridge parsing must be bounds-checked and avoid unsafe Rust by default.
+- **Validation**: Prefer small unit tests for pure CPU/device behavior and ROM-driven integration tests for compatibility.
+
+## Key Decisions
+
+| Decision | Rationale | Outcome |
+|----------|-----------|---------|
+| Map the brownfield codebase before initialization | Existing code and docs should define validated context instead of treating the repo as blank | ✓ Good |
+| Target DMG behavior first | The docs and available tests support a focused first emulator target, while CGB multiplies hardware variance | — Pending |
+| Build around a Bus abstraction | CPU-visible memory behavior spans cartridge, RAM, timer, PPU, joypad, interrupts, and later audio | — Pending |
+| Replace text ROM loading with byte loading before emulator work | Game Boy ROMs are binary files and the current UTF-8 path is only a placeholder | — Pending |
+| Use blargg/mooneye ROMs for milestone validation | Emulator correctness depends on edge cases that ordinary demos can miss | — Pending |
+
+## Evolution
+
+This document evolves at phase transitions and milestone boundaries.
+
+**After each phase transition** (via `$gsd-transition`):
+1. Requirements invalidated? -> Move to Out of Scope with reason
+2. Requirements validated? -> Move to Validated with phase reference
+3. New requirements emerged? -> Add to Active
+4. Decisions to log? -> Add to Key Decisions
+5. "What This Is" still accurate? -> Update if drifted
+
+**After each milestone** (via `$gsd-complete-milestone`):
+1. Full review of all sections
+2. Core Value check - still the right priority?
+3. Audit Out of Scope - reasons still valid?
+4. Update Context with current state
+
+---
+*Last updated: 2026-05-02 after initialization*

--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -23,7 +23,9 @@ GameGirl must execute DMG Game Boy ROMs accurately enough that behavior is drive
 
 - [ ] Load cartridge files as binary data and parse enough header metadata to identify the ROM and initial cartridge behavior
 - [ ] Define a DMG memory bus with 16-bit addressing and 8-bit read/write access
-- [ ] Implement CPU register state, instruction fetch/decode/execute flow, flags, stack behavior, and core instruction groups
+- [ ] Start execution from documented post-boot DMG state rather than emulating the Nintendo boot ROM in v1.0
+- [ ] Implement CPU register state, instruction fetch/decode/execute flow, flags, stack behavior, and staged core instruction groups
+- [ ] Capture minimal serial output from `FF01`/`FF02` so ROM fixtures can report test results early
 - [ ] Add timer and interrupt state using hardware-oriented timing rules, including delayed interrupt enable behavior
 - [ ] Introduce PPU mode timing and VRAM/OAM access restrictions before full rendering
 - [ ] Run automated checks against local blargg and mooneye ROM fixtures as emulator capabilities appear
@@ -34,6 +36,7 @@ GameGirl must execute DMG Game Boy ROMs accurately enough that behavior is drive
 - Full audio output — defer until CPU, bus, timer, interrupts, PPU timing, and basic cartridge execution are grounded
 - Polished desktop UI — defer until the emulator core can run meaningful ROMs
 - Broad MBC coverage beyond the first cartridge path — start with the simplest supported cartridge behavior before expanding
+- Nintendo boot ROM emulation in v1.0 — start from documented post-boot DMG state and make the assumption explicit
 - Cycle-perfect edge cases everywhere in the first milestone — capture architecture that can support precision, then tighten with tests
 
 ## Context
@@ -62,6 +65,8 @@ GameGirl must execute DMG Game Boy ROMs accurately enough that behavior is drive
 | Build around a Bus abstraction | CPU-visible memory behavior spans cartridge, RAM, timer, PPU, joypad, interrupts, and later audio | — Pending |
 | Replace text ROM loading with byte loading before emulator work | Game Boy ROMs are binary files and the current UTF-8 path is only a placeholder | — Pending |
 | Use blargg/mooneye ROMs for milestone validation | Emulator correctness depends on edge cases that ordinary demos can miss | — Pending |
+| Insert a minimal serial ROM harness before timer/interrupt work | CPU changes should encounter ROM-style failures early instead of waiting for a broad validation phase | — Pending |
+| Skip Nintendo boot ROM emulation in v1.0 | Starting at documented post-boot DMG state keeps the first milestone focused and aligns CPU defaults around `PC = 0x0100` | — Pending |
 
 ## Evolution
 
@@ -81,4 +86,4 @@ This document evolves at phase transitions and milestone boundaries.
 4. Update Context with current state
 
 ---
-*Last updated: 2026-05-02 after initialization*
+*Last updated: 2026-05-02 after roadmap feedback insertion*

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -1,0 +1,137 @@
+# Requirements: GameGirl
+
+**Defined:** 2026-05-02
+**Core Value:** GameGirl must execute DMG Game Boy ROMs accurately enough that behavior is driven by hardware rules and verified by known test ROMs, not by ad hoc demo success.
+
+## v1 Requirements
+
+Requirements for the initial emulator-core milestone. Each maps to roadmap phases.
+
+### Cartridge
+
+- [ ] **CART-01**: User can provide a `.gb` or `.gbc` file path and the emulator reads the ROM as binary bytes.
+- [ ] **CART-02**: User receives a clear error when the ROM path is missing, unreadable, too short for a header, or invalid.
+- [ ] **CART-03**: Emulator can parse cartridge header fields needed for planning execution: title, cartridge type, ROM size, RAM size, and entry/header region.
+- [ ] **CART-04**: Emulator can construct a ROM-only cartridge representation that supports reads from fixed ROM address ranges.
+
+### Bus
+
+- [ ] **BUS-01**: Emulator exposes a Bus API that can read and write 8-bit values through the 16-bit DMG address space.
+- [ ] **BUS-02**: Bus routes reads for cartridge ROM, work RAM, high RAM, interrupt enable, and basic I/O register ranges.
+- [ ] **BUS-03**: Bus routes writes for writable memory and I/O registers without letting CPU instruction code bypass the Bus.
+- [ ] **BUS-04**: Bus behavior is covered by tests for representative address ranges and invalid/unusable ranges.
+
+### CPU
+
+- [ ] **CPU-01**: Emulator can initialize DMG CPU registers and program counter/stack pointer to documented post-boot values.
+- [ ] **CPU-02**: CPU fetches opcodes through the Bus and advances `PC` according to instruction length.
+- [ ] **CPU-03**: CPU can execute initial load and control instructions needed for simple ROM startup.
+- [ ] **CPU-04**: CPU can execute arithmetic/logical instruction helpers with correct `Z`, `N`, `H`, and `C` flag behavior.
+- [ ] **CPU-05**: CPU can execute jump, call, return, and stack helpers needed for ROM control flow.
+- [ ] **CPU-06**: Each implemented CPU instruction reports elapsed machine cycles for device timing.
+
+### Timing
+
+- [ ] **TIME-01**: Timer implements `DIV`, `TIMA`, `TMA`, and `TAC` using an internal system counter model.
+- [ ] **TIME-02**: Timer increments `TIMA` from selected counter-bit falling edges and handles `DIV`/`TAC` write side effects.
+- [ ] **TIME-03**: Timer handles `TIMA` overflow reload and timer interrupt request timing.
+- [ ] **INT-01**: Emulator models `IE`, `IF`, and CPU-internal `IME`, including delayed `ei` behavior.
+- [ ] **INT-02**: CPU can service enabled interrupts by clearing `IME`, clearing the requested `IF` bit, pushing `PC`, and jumping to the correct vector.
+
+### Validation
+
+- [ ] **TEST-01**: Cargo tests cover cartridge parsing, Bus address routing, CPU flags/instructions, timer behavior, and interrupt behavior introduced in v1.
+- [ ] **TEST-02**: Emulator has a ROM test harness that can run at least one checked-in blargg or mooneye ROM with a deterministic timeout.
+- [ ] **TEST-03**: ROM harness can report pass/fail through a documented signal such as serial output or debug-break behavior.
+
+### PPU
+
+- [ ] **PPU-01**: Emulator has a PPU state skeleton that advances LY/dot/mode state from elapsed cycles.
+- [ ] **PPU-02**: Bus enforces VRAM and OAM access restrictions based on current PPU mode.
+- [ ] **PPU-03**: PPU mode transitions can request VBlank and LCD-related interrupts through the shared interrupt path.
+
+## v2 Requirements
+
+Deferred to future release. Tracked but not in current roadmap.
+
+### Rendering
+
+- **REND-01**: Emulator can render DMG background tiles into a 160x144 frame buffer.
+- **REND-02**: Emulator can render Window layer behavior.
+- **REND-03**: Emulator can render Sprite/OAM behavior with scanline limits and priority rules.
+
+### Input
+
+- **INPT-01**: User can control Joypad state for D-pad, A, B, Select, and Start.
+- **INPT-02**: Emulator can request Joypad interrupts on relevant input changes.
+
+### Cartridge Expansion
+
+- **MBC-01**: Emulator can run MBC1 ROMs.
+- **MBC-02**: Emulator can run MBC3 ROMs with RAM behavior.
+- **MBC-03**: Emulator can run MBC5 ROMs.
+- **SAVE-01**: Emulator can persist and reload battery-backed external RAM.
+
+### Audio and Host
+
+- **APU-01**: Emulator can model DMG pulse, wave, and noise channel state.
+- **APU-02**: Emulator can output audio through a host audio backend.
+- **HOST-01**: User can run ROMs in an interactive desktop window.
+
+### Compatibility
+
+- **CGB-01**: Emulator can select and execute Color Game Boy behavior.
+
+## Out of Scope
+
+Explicitly excluded. Documented to prevent scope creep.
+
+| Feature | Reason |
+|---------|--------|
+| CGB support in v1 | DMG correctness is already a large hardware target; CGB adds banked VRAM/WRAM, palettes, and speed behavior |
+| Full pixel rendering in v1 | PPU mode/access correctness should land before visual output |
+| Audio output in v1 | APU is timing-sensitive and should follow CPU/bus/timer stability |
+| Desktop UI in v1 | Core correctness and automated validation matter before host polish |
+| Broad MBC support in v1 | Start with ROM-only cartridge behavior, then expand once Bus and cartridge boundaries are proven |
+| Cycle-perfect completion for every subsystem | v1 establishes architecture and selected verified behavior; later phases tighten compatibility |
+
+## Traceability
+
+Which phases cover which requirements. Updated during roadmap creation.
+
+| Requirement | Phase | Status |
+|-------------|-------|--------|
+| CART-01 | TBD | Pending |
+| CART-02 | TBD | Pending |
+| CART-03 | TBD | Pending |
+| CART-04 | TBD | Pending |
+| BUS-01 | TBD | Pending |
+| BUS-02 | TBD | Pending |
+| BUS-03 | TBD | Pending |
+| BUS-04 | TBD | Pending |
+| CPU-01 | TBD | Pending |
+| CPU-02 | TBD | Pending |
+| CPU-03 | TBD | Pending |
+| CPU-04 | TBD | Pending |
+| CPU-05 | TBD | Pending |
+| CPU-06 | TBD | Pending |
+| TIME-01 | TBD | Pending |
+| TIME-02 | TBD | Pending |
+| TIME-03 | TBD | Pending |
+| INT-01 | TBD | Pending |
+| INT-02 | TBD | Pending |
+| TEST-01 | TBD | Pending |
+| TEST-02 | TBD | Pending |
+| TEST-03 | TBD | Pending |
+| PPU-01 | TBD | Pending |
+| PPU-02 | TBD | Pending |
+| PPU-03 | TBD | Pending |
+
+**Coverage:**
+- v1 requirements: 25 total
+- Mapped to phases: 0
+- Unmapped: 25
+
+---
+*Requirements defined: 2026-05-02*
+*Last updated: 2026-05-02 after initial definition*

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -9,18 +9,18 @@ Requirements for the initial emulator-core milestone. Each maps to roadmap phase
 
 ### Cartridge
 
-- [ ] **CART-01**: User can provide a `.gb` or `.gbc` file path and the emulator reads the ROM as binary bytes.
-- [ ] **CART-02**: User receives a clear error when the ROM path is missing, unreadable, too short for a header, or invalid.
-- [ ] **CART-03**: Emulator can parse cartridge header fields needed for planning execution: title, cartridge type, ROM size, RAM size, and entry/header region.
-- [ ] **CART-04**: Emulator can construct a ROM-only cartridge representation that supports reads from fixed ROM address ranges.
-- [ ] **CART-05**: Non-ROM-only cartridge types are parsed far enough to report their type, then return `UnsupportedCartridgeType` until MBC support is added.
+- [x] **CART-01**: User can provide a `.gb` or `.gbc` file path and the emulator reads the ROM as binary bytes.
+- [x] **CART-02**: User receives a clear error when the ROM path is missing, unreadable, too short for a header, or invalid.
+- [x] **CART-03**: Emulator can parse cartridge header fields needed for planning execution: title, cartridge type, ROM size, RAM size, and entry/header region.
+- [x] **CART-04**: Emulator can construct a ROM-only cartridge representation that supports reads from fixed ROM address ranges.
+- [x] **CART-05**: Non-ROM-only cartridge types are parsed far enough to report their type, then return `UnsupportedCartridgeType` until MBC support is added.
 
 ### Bus
 
-- [ ] **BUS-01**: Emulator exposes a Bus API that can read and write 8-bit values through the 16-bit DMG address space.
-- [ ] **BUS-02**: Bus routes reads for cartridge ROM, work RAM, high RAM, interrupt enable, and basic I/O register ranges.
-- [ ] **BUS-03**: Bus routes writes for writable memory and I/O registers without letting CPU instruction code bypass the Bus.
-- [ ] **BUS-04**: Bus behavior is covered by tests for representative address ranges and invalid/unusable ranges.
+- [x] **BUS-01**: Emulator exposes a Bus API that can read and write 8-bit values through the 16-bit DMG address space.
+- [x] **BUS-02**: Bus routes reads for cartridge ROM, work RAM, high RAM, interrupt enable, and basic I/O register ranges.
+- [x] **BUS-03**: Bus routes writes for writable memory and I/O registers without letting CPU instruction code bypass the Bus.
+- [x] **BUS-04**: Bus behavior is covered by tests for representative address ranges and invalid/unusable ranges.
 
 ### Boot Model
 
@@ -111,15 +111,15 @@ Which phases cover which requirements. Updated during roadmap creation.
 
 | Requirement | Phase | Status |
 |-------------|-------|--------|
-| CART-01 | Phase 1 | Pending |
-| CART-02 | Phase 1 | Pending |
-| CART-03 | Phase 1 | Pending |
-| CART-04 | Phase 1 | Pending |
-| CART-05 | Phase 1 | Pending |
-| BUS-01 | Phase 1 | Pending |
-| BUS-02 | Phase 1 | Pending |
-| BUS-03 | Phase 1 | Pending |
-| BUS-04 | Phase 1 | Pending |
+| CART-01 | Phase 1 | Complete |
+| CART-02 | Phase 1 | Complete |
+| CART-03 | Phase 1 | Complete |
+| CART-04 | Phase 1 | Complete |
+| CART-05 | Phase 1 | Complete |
+| BUS-01 | Phase 1 | Complete |
+| BUS-02 | Phase 1 | Complete |
+| BUS-03 | Phase 1 | Complete |
+| BUS-04 | Phase 1 | Complete |
 | BOOT-01 | Phase 2 | Pending |
 | CPU-01 | Phase 2 | Pending |
 | CPU-02 | Phase 2 | Pending |
@@ -148,4 +148,4 @@ Which phases cover which requirements. Updated during roadmap creation.
 
 ---
 *Requirements defined: 2026-05-02*
-*Last updated: 2026-05-02 after roadmap feedback insertion*
+*Last updated: 2026-05-02 after Phase 1 completion*

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -101,37 +101,37 @@ Which phases cover which requirements. Updated during roadmap creation.
 
 | Requirement | Phase | Status |
 |-------------|-------|--------|
-| CART-01 | TBD | Pending |
-| CART-02 | TBD | Pending |
-| CART-03 | TBD | Pending |
-| CART-04 | TBD | Pending |
-| BUS-01 | TBD | Pending |
-| BUS-02 | TBD | Pending |
-| BUS-03 | TBD | Pending |
-| BUS-04 | TBD | Pending |
-| CPU-01 | TBD | Pending |
-| CPU-02 | TBD | Pending |
-| CPU-03 | TBD | Pending |
-| CPU-04 | TBD | Pending |
-| CPU-05 | TBD | Pending |
-| CPU-06 | TBD | Pending |
-| TIME-01 | TBD | Pending |
-| TIME-02 | TBD | Pending |
-| TIME-03 | TBD | Pending |
-| INT-01 | TBD | Pending |
-| INT-02 | TBD | Pending |
-| TEST-01 | TBD | Pending |
-| TEST-02 | TBD | Pending |
-| TEST-03 | TBD | Pending |
-| PPU-01 | TBD | Pending |
-| PPU-02 | TBD | Pending |
-| PPU-03 | TBD | Pending |
+| CART-01 | Phase 1 | Pending |
+| CART-02 | Phase 1 | Pending |
+| CART-03 | Phase 1 | Pending |
+| CART-04 | Phase 1 | Pending |
+| BUS-01 | Phase 1 | Pending |
+| BUS-02 | Phase 1 | Pending |
+| BUS-03 | Phase 1 | Pending |
+| BUS-04 | Phase 1 | Pending |
+| CPU-01 | Phase 2 | Pending |
+| CPU-02 | Phase 2 | Pending |
+| CPU-03 | Phase 2 | Pending |
+| CPU-04 | Phase 2 | Pending |
+| CPU-05 | Phase 2 | Pending |
+| CPU-06 | Phase 2 | Pending |
+| TIME-01 | Phase 3 | Pending |
+| TIME-02 | Phase 3 | Pending |
+| TIME-03 | Phase 3 | Pending |
+| INT-01 | Phase 3 | Pending |
+| INT-02 | Phase 3 | Pending |
+| TEST-01 | Phase 4 | Pending |
+| TEST-02 | Phase 4 | Pending |
+| TEST-03 | Phase 4 | Pending |
+| PPU-01 | Phase 5 | Pending |
+| PPU-02 | Phase 5 | Pending |
+| PPU-03 | Phase 5 | Pending |
 
 **Coverage:**
 - v1 requirements: 25 total
-- Mapped to phases: 0
-- Unmapped: 25
+- Mapped to phases: 25
+- Unmapped: 0
 
 ---
 *Requirements defined: 2026-05-02*
-*Last updated: 2026-05-02 after initial definition*
+*Last updated: 2026-05-02 after roadmap traceability mapping*

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -13,6 +13,7 @@ Requirements for the initial emulator-core milestone. Each maps to roadmap phase
 - [ ] **CART-02**: User receives a clear error when the ROM path is missing, unreadable, too short for a header, or invalid.
 - [ ] **CART-03**: Emulator can parse cartridge header fields needed for planning execution: title, cartridge type, ROM size, RAM size, and entry/header region.
 - [ ] **CART-04**: Emulator can construct a ROM-only cartridge representation that supports reads from fixed ROM address ranges.
+- [ ] **CART-05**: Non-ROM-only cartridge types are parsed far enough to report their type, then return `UnsupportedCartridgeType` until MBC support is added.
 
 ### Bus
 
@@ -20,6 +21,10 @@ Requirements for the initial emulator-core milestone. Each maps to roadmap phase
 - [ ] **BUS-02**: Bus routes reads for cartridge ROM, work RAM, high RAM, interrupt enable, and basic I/O register ranges.
 - [ ] **BUS-03**: Bus routes writes for writable memory and I/O registers without letting CPU instruction code bypass the Bus.
 - [ ] **BUS-04**: Bus behavior is covered by tests for representative address ranges and invalid/unusable ranges.
+
+### Boot Model
+
+- [ ] **BOOT-01**: v1.0 starts from documented post-boot DMG state, including `PC = 0x0100`, and does not emulate the Nintendo boot ROM.
 
 ### CPU
 
@@ -38,11 +43,16 @@ Requirements for the initial emulator-core milestone. Each maps to roadmap phase
 - [ ] **INT-01**: Emulator models `IE`, `IF`, and CPU-internal `IME`, including delayed `ei` behavior.
 - [ ] **INT-02**: CPU can service enabled interrupts by clearing `IME`, clearing the requested `IF` bit, pushing `PC`, and jumping to the correct vector.
 
+### Serial
+
+- [ ] **SERIAL-01**: Emulator captures test ROM serial output through `SB` (`0xFF01`) and `SC` (`0xFF02`) by appending `SB` to a test buffer when `SC == 0x81`, without claiming full link-cable accuracy.
+
 ### Validation
 
 - [ ] **TEST-01**: Cargo tests cover cartridge parsing, Bus address routing, CPU flags/instructions, timer behavior, and interrupt behavior introduced in v1.
-- [ ] **TEST-02**: Emulator has a ROM test harness that can run at least one checked-in blargg or mooneye ROM with a deterministic timeout.
+- [ ] **TEST-02**: Emulator has a ROM test harness that can run at least one checked-in `.gb` fixture, custom or known-test, with a deterministic timeout.
 - [ ] **TEST-03**: ROM harness can report pass/fail through a documented signal such as serial output or debug-break behavior.
+- [ ] **TEST-04**: Expanded ROM validation can run selected blargg or mooneye ROMs matched to implemented CPU/timer/interrupt capability, with documented expectations.
 
 ### PPU
 
@@ -105,33 +115,37 @@ Which phases cover which requirements. Updated during roadmap creation.
 | CART-02 | Phase 1 | Pending |
 | CART-03 | Phase 1 | Pending |
 | CART-04 | Phase 1 | Pending |
+| CART-05 | Phase 1 | Pending |
 | BUS-01 | Phase 1 | Pending |
 | BUS-02 | Phase 1 | Pending |
 | BUS-03 | Phase 1 | Pending |
 | BUS-04 | Phase 1 | Pending |
+| BOOT-01 | Phase 2 | Pending |
 | CPU-01 | Phase 2 | Pending |
 | CPU-02 | Phase 2 | Pending |
 | CPU-03 | Phase 2 | Pending |
 | CPU-04 | Phase 2 | Pending |
 | CPU-05 | Phase 2 | Pending |
 | CPU-06 | Phase 2 | Pending |
+| SERIAL-01 | Phase 2.1 | Pending |
 | TIME-01 | Phase 3 | Pending |
 | TIME-02 | Phase 3 | Pending |
 | TIME-03 | Phase 3 | Pending |
 | INT-01 | Phase 3 | Pending |
 | INT-02 | Phase 3 | Pending |
 | TEST-01 | Phase 4 | Pending |
-| TEST-02 | Phase 4 | Pending |
-| TEST-03 | Phase 4 | Pending |
+| TEST-02 | Phase 2.1 | Pending |
+| TEST-03 | Phase 2.1 | Pending |
+| TEST-04 | Phase 4 | Pending |
 | PPU-01 | Phase 5 | Pending |
 | PPU-02 | Phase 5 | Pending |
 | PPU-03 | Phase 5 | Pending |
 
 **Coverage:**
-- v1 requirements: 25 total
-- Mapped to phases: 25
+- v1 requirements: 29 total
+- Mapped to phases: 29
 - Unmapped: 0
 
 ---
 *Requirements defined: 2026-05-02*
-*Last updated: 2026-05-02 after roadmap traceability mapping*
+*Last updated: 2026-05-02 after roadmap feedback insertion*

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-GameGirl v1.0 turns the current Rust CLI scaffold into a testable DMG emulator core foundation. The roadmap starts with binary cartridge loading and a Bus-centered memory map, then adds CPU stepping, timing/interrupt behavior, automated ROM validation, and finally PPU mode/access foundations before any full rendering, audio, CGB, or UI polish.
+GameGirl v1.0 turns the current Rust CLI scaffold into a testable DMG emulator core foundation. The roadmap starts with binary cartridge loading and a Bus-centered memory map, then adds a deliberately staged CPU core, inserts minimal serial/ROM validation before timer work, expands timing/interrupt validation, and finally adds PPU mode/access foundations before any full rendering, audio, CGB, or UI polish.
 
 ## Phases
 
@@ -13,9 +13,10 @@ GameGirl v1.0 turns the current Rust CLI scaffold into a testable DMG emulator c
 Decimal phases appear between their surrounding integers in numeric order.
 
 - [ ] **Phase 1: Cartridge and Bus Foundation** - Replace placeholder ROM text loading with binary cartridge parsing and a tested DMG Bus skeleton
-- [ ] **Phase 2: CPU Core Foundation** - Add DMG CPU state, fetch/decode/execute flow, initial instruction families, and cycle reporting
+- [ ] **Phase 2: CPU Core Foundation** - Add DMG CPU state, Bus-backed fetch/decode/execute flow, staged initial instruction groups, and cycle reporting
+- [ ] **Phase 2.1: Minimal Serial and ROM Test Harness INSERTED** - Run small ROM fixtures under deterministic limits and capture serial test output
 - [ ] **Phase 3: Timer and Interrupt Foundations** - Model timer registers, interrupt state, delayed `ei`, and interrupt service behavior
-- [ ] **Phase 4: Automated Validation Harness** - Turn local test ROM assets into reproducible Cargo-based validation
+- [ ] **Phase 4: Automated Validation Harness Expansion** - Expand the early ROM harness into reproducible Cargo-based validation against capability-appropriate test ROMs
 - [ ] **Phase 5: PPU Mode Skeleton and Access Rules** - Add cycle-driven PPU mode state, VRAM/OAM access restrictions, and interrupt hooks
 
 ## Phase Details
@@ -23,13 +24,14 @@ Decimal phases appear between their surrounding integers in numeric order.
 ### Phase 1: Cartridge and Bus Foundation
 **Goal**: User can load ROM bytes into a cartridge representation and exercise a Bus API for core DMG memory ranges.
 **Depends on**: Nothing (first phase)
-**Requirements**: [CART-01, CART-02, CART-03, CART-04, BUS-01, BUS-02, BUS-03, BUS-04]
+**Requirements**: [CART-01, CART-02, CART-03, CART-04, CART-05, BUS-01, BUS-02, BUS-03, BUS-04]
 **UI hint**: no
 **Success Criteria** (what must be TRUE):
   1. User can run the CLI with a `.gb` path and the program reads binary bytes without UTF-8 assumptions.
   2. User gets clear errors for missing, unreadable, too-short, or invalid ROM inputs.
   3. Cartridge header parsing exposes title, type, ROM size, RAM size, and entry/header region data in tests.
-  4. Bus read/write tests cover cartridge ROM, WRAM, HRAM, interrupt enable, I/O, and representative unusable ranges.
+  4. Non-ROM-only cartridge types are parsed far enough to report their type, then fail with `UnsupportedCartridgeType` until MBC support is added.
+  5. Bus read/write tests cover cartridge ROM, WRAM, HRAM, interrupt enable, I/O, and representative unusable ranges.
 **Plans**: 3 plans
 
 Plans:
@@ -38,25 +40,44 @@ Plans:
 - [ ] 01-03: Introduce Bus address routing with focused tests
 
 ### Phase 2: CPU Core Foundation
-**Goal**: Emulator has a DMG CPU core that fetches through the Bus, executes initial instruction groups, updates flags, and reports cycles.
+**Goal**: Emulator has a DMG CPU core that fetches through the Bus, starts from documented post-boot state, executes initial instruction groups in staged slices, updates flags, and reports cycles.
 **Depends on**: Phase 1
-**Requirements**: [CPU-01, CPU-02, CPU-03, CPU-04, CPU-05, CPU-06]
+**Requirements**: [BOOT-01, CPU-01, CPU-02, CPU-03, CPU-04, CPU-05, CPU-06]
 **UI hint**: no
 **Success Criteria** (what must be TRUE):
-  1. CPU initializes DMG register, `PC`, and `SP` state to documented post-boot defaults.
+  1. v1.0 starts from documented post-boot DMG state and does not emulate the Nintendo boot ROM.
   2. CPU fetches opcodes through Bus and advances `PC` by instruction length.
-  3. Load/control, arithmetic/logical, jump/call/return, and stack helpers have targeted unit tests.
+  3. NOP, HALT/STOP placeholders, basic 8-bit loads, arithmetic/logical helpers, and control-flow/stack helpers are implemented through small plan slices with targeted unit tests.
   4. Each implemented instruction reports elapsed machine cycles for downstream device timing.
-**Plans**: 3 plans
+  5. CB-prefixed opcodes are either represented by a clear skeleton or explicitly deferred with deterministic unsupported behavior.
+**Plans**: 5 plans
 
 Plans:
 - [ ] 02-01: Add CPU registers, flags, boot defaults, and fetch skeleton
-- [ ] 02-02: Implement initial load/control and arithmetic/logical helpers with flag tests
-- [ ] 02-03: Implement control-flow/stack helpers and cycle-returning step behavior
+- [ ] 02-02: Implement NOP, HALT/STOP placeholders, and basic 8-bit loads
+- [ ] 02-03: Implement INC/DEC/ADD/SUB/AND/OR/XOR/CP with flag tests
+- [ ] 02-04: Implement JP/JR/CALL/RET/RST and stack helpers
+- [ ] 02-05: Add CB-prefix skeleton or explicit CB deferral plus cycle-returning step behavior
+
+### Phase 2.1: Minimal Serial and ROM Test Harness INSERTED
+**Goal**: Emulator can run small ROM fixtures under a deterministic step limit and collect serial test output.
+**Depends on**: Phase 2
+**Requirements**: [SERIAL-01, TEST-02, TEST-03]
+**UI hint**: no
+**Success Criteria** (what must be TRUE):
+  1. Harness can load a checked-in `.gb` fixture through the cartridge and Bus path.
+  2. Emulator can run until timeout or an explicit pass/fail signal, and timeout is reported as failure.
+  3. Serial output via `SB` (`0xFF01`) and `SC` (`0xFF02`) is captured into a test buffer when a test transfer is requested.
+  4. At least one tiny custom ROM or capability-appropriate known test ROM fixture runs deterministically.
+**Plans**: 2 plans
+
+Plans:
+- [ ] 02.1-01: Add minimal serial transfer register handling for ROM test output
+- [ ] 02.1-02: Build deterministic ROM step harness and first fixture assertion
 
 ### Phase 3: Timer and Interrupt Foundations
 **Goal**: Emulator can advance timer state from CPU cycles and service enabled DMG interrupts through shared `IE`/`IF`/`IME` behavior.
-**Depends on**: Phase 2
+**Depends on**: Phase 2.1
 **Requirements**: [TIME-01, TIME-02, TIME-03, INT-01, INT-02]
 **UI hint**: no
 **Success Criteria** (what must be TRUE):
@@ -71,20 +92,21 @@ Plans:
 - [ ] 03-02: Implement interrupt registers, delayed `ei`, and interrupt service flow
 - [ ] 03-03: Integrate CPU cycles with timer/interrupt progression and tests
 
-### Phase 4: Automated Validation Harness
-**Goal**: User can run reproducible Cargo tests that exercise emulator behavior and at least one checked-in ROM fixture with deterministic pass/fail reporting.
+### Phase 4: Automated Validation Harness Expansion
+**Goal**: User can run reproducible Cargo tests that expand the early ROM harness into capability-appropriate blargg/mooneye validation with deterministic pass/fail reporting.
 **Depends on**: Phase 3
-**Requirements**: [TEST-01, TEST-02, TEST-03]
+**Requirements**: [TEST-01, TEST-03, TEST-04]
 **UI hint**: no
 **Success Criteria** (what must be TRUE):
   1. Cargo tests cover cartridge parsing, Bus routing, CPU flags/instructions, timer behavior, and interrupt behavior introduced so far.
-  2. A ROM harness can load and run at least one checked-in blargg or mooneye ROM with a deterministic timeout.
+  2. The ROM harness can load and run at least one checked-in blargg or mooneye ROM matched to the implemented CPU/timer/interrupt capability.
   3. The harness documents and asserts its pass/fail signal, such as serial output or debug-break behavior.
+  4. Test ROM selection is documented so unsupported subsystems do not masquerade as emulator failures.
 **Plans**: 2 plans
 
 Plans:
 - [ ] 04-01: Consolidate unit/integration coverage for v1 core behavior
-- [ ] 04-02: Build the initial ROM test harness with pass/fail reporting
+- [ ] 04-02: Expand ROM harness with capability-gated blargg/mooneye pass/fail reporting
 
 ### Phase 5: PPU Mode Skeleton and Access Rules
 **Goal**: Emulator has enough PPU timing state for Bus access restrictions and interrupt hooks, without committing to full pixel rendering yet.
@@ -106,12 +128,13 @@ Plans:
 ## Progress
 
 **Execution Order:**
-Phases execute in numeric order: 1 -> 2 -> 3 -> 4 -> 5
+Phases execute in numeric order: 1 -> 2 -> 2.1 -> 3 -> 4 -> 5
 
 | Phase | Plans Complete | Status | Completed |
 |-------|----------------|--------|-----------|
 | 1. Cartridge and Bus Foundation | 0/3 | Not started | - |
-| 2. CPU Core Foundation | 0/3 | Not started | - |
+| 2. CPU Core Foundation | 0/5 | Not started | - |
+| 2.1 Minimal Serial and ROM Test Harness INSERTED | 0/2 | Not started | - |
 | 3. Timer and Interrupt Foundations | 0/3 | Not started | - |
-| 4. Automated Validation Harness | 0/2 | Not started | - |
+| 4. Automated Validation Harness Expansion | 0/2 | Not started | - |
 | 5. PPU Mode Skeleton and Access Rules | 0/3 | Not started | - |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -1,0 +1,117 @@
+# Roadmap: GameGirl
+
+## Overview
+
+GameGirl v1.0 turns the current Rust CLI scaffold into a testable DMG emulator core foundation. The roadmap starts with binary cartridge loading and a Bus-centered memory map, then adds CPU stepping, timing/interrupt behavior, automated ROM validation, and finally PPU mode/access foundations before any full rendering, audio, CGB, or UI polish.
+
+## Phases
+
+**Phase Numbering:**
+- Integer phases (1, 2, 3): Planned milestone work
+- Decimal phases (2.1, 2.2): Urgent insertions (marked with INSERTED)
+
+Decimal phases appear between their surrounding integers in numeric order.
+
+- [ ] **Phase 1: Cartridge and Bus Foundation** - Replace placeholder ROM text loading with binary cartridge parsing and a tested DMG Bus skeleton
+- [ ] **Phase 2: CPU Core Foundation** - Add DMG CPU state, fetch/decode/execute flow, initial instruction families, and cycle reporting
+- [ ] **Phase 3: Timer and Interrupt Foundations** - Model timer registers, interrupt state, delayed `ei`, and interrupt service behavior
+- [ ] **Phase 4: Automated Validation Harness** - Turn local test ROM assets into reproducible Cargo-based validation
+- [ ] **Phase 5: PPU Mode Skeleton and Access Rules** - Add cycle-driven PPU mode state, VRAM/OAM access restrictions, and interrupt hooks
+
+## Phase Details
+
+### Phase 1: Cartridge and Bus Foundation
+**Goal**: User can load ROM bytes into a cartridge representation and exercise a Bus API for core DMG memory ranges.
+**Depends on**: Nothing (first phase)
+**Requirements**: [CART-01, CART-02, CART-03, CART-04, BUS-01, BUS-02, BUS-03, BUS-04]
+**UI hint**: no
+**Success Criteria** (what must be TRUE):
+  1. User can run the CLI with a `.gb` path and the program reads binary bytes without UTF-8 assumptions.
+  2. User gets clear errors for missing, unreadable, too-short, or invalid ROM inputs.
+  3. Cartridge header parsing exposes title, type, ROM size, RAM size, and entry/header region data in tests.
+  4. Bus read/write tests cover cartridge ROM, WRAM, HRAM, interrupt enable, I/O, and representative unusable ranges.
+**Plans**: 3 plans
+
+Plans:
+- [ ] 01-01: Replace text ROM loading with binary cartridge loading and CLI errors
+- [ ] 01-02: Parse cartridge headers and model ROM-only cartridge reads
+- [ ] 01-03: Introduce Bus address routing with focused tests
+
+### Phase 2: CPU Core Foundation
+**Goal**: Emulator has a DMG CPU core that fetches through the Bus, executes initial instruction groups, updates flags, and reports cycles.
+**Depends on**: Phase 1
+**Requirements**: [CPU-01, CPU-02, CPU-03, CPU-04, CPU-05, CPU-06]
+**UI hint**: no
+**Success Criteria** (what must be TRUE):
+  1. CPU initializes DMG register, `PC`, and `SP` state to documented post-boot defaults.
+  2. CPU fetches opcodes through Bus and advances `PC` by instruction length.
+  3. Load/control, arithmetic/logical, jump/call/return, and stack helpers have targeted unit tests.
+  4. Each implemented instruction reports elapsed machine cycles for downstream device timing.
+**Plans**: 3 plans
+
+Plans:
+- [ ] 02-01: Add CPU registers, flags, boot defaults, and fetch skeleton
+- [ ] 02-02: Implement initial load/control and arithmetic/logical helpers with flag tests
+- [ ] 02-03: Implement control-flow/stack helpers and cycle-returning step behavior
+
+### Phase 3: Timer and Interrupt Foundations
+**Goal**: Emulator can advance timer state from CPU cycles and service enabled DMG interrupts through shared `IE`/`IF`/`IME` behavior.
+**Depends on**: Phase 2
+**Requirements**: [TIME-01, TIME-02, TIME-03, INT-01, INT-02]
+**UI hint**: no
+**Success Criteria** (what must be TRUE):
+  1. Timer tests show `DIV`, `TIMA`, `TMA`, and `TAC` behavior driven by an internal system counter.
+  2. `DIV` and `TAC` writes can trigger documented timer edge effects.
+  3. `TIMA` overflow reload and timer interrupt request timing are covered by tests.
+  4. CPU interrupt tests cover `IE`, `IF`, `IME`, delayed `ei`, vector jumps, `PC` push, and request clearing.
+**Plans**: 3 plans
+
+Plans:
+- [ ] 03-01: Implement timer registers with internal counter and edge behavior
+- [ ] 03-02: Implement interrupt registers, delayed `ei`, and interrupt service flow
+- [ ] 03-03: Integrate CPU cycles with timer/interrupt progression and tests
+
+### Phase 4: Automated Validation Harness
+**Goal**: User can run reproducible Cargo tests that exercise emulator behavior and at least one checked-in ROM fixture with deterministic pass/fail reporting.
+**Depends on**: Phase 3
+**Requirements**: [TEST-01, TEST-02, TEST-03]
+**UI hint**: no
+**Success Criteria** (what must be TRUE):
+  1. Cargo tests cover cartridge parsing, Bus routing, CPU flags/instructions, timer behavior, and interrupt behavior introduced so far.
+  2. A ROM harness can load and run at least one checked-in blargg or mooneye ROM with a deterministic timeout.
+  3. The harness documents and asserts its pass/fail signal, such as serial output or debug-break behavior.
+**Plans**: 2 plans
+
+Plans:
+- [ ] 04-01: Consolidate unit/integration coverage for v1 core behavior
+- [ ] 04-02: Build the initial ROM test harness with pass/fail reporting
+
+### Phase 5: PPU Mode Skeleton and Access Rules
+**Goal**: Emulator has enough PPU timing state for Bus access restrictions and interrupt hooks, without committing to full pixel rendering yet.
+**Depends on**: Phase 4
+**Requirements**: [PPU-01, PPU-02, PPU-03]
+**UI hint**: no
+**Success Criteria** (what must be TRUE):
+  1. PPU state advances dot, LY, and mode values from elapsed CPU cycles.
+  2. Bus read/write tests enforce VRAM and OAM access restrictions based on PPU mode.
+  3. PPU mode transitions can request VBlank and LCD-related interrupts through the shared interrupt path.
+  4. Rendering, audio, CGB, and host UI remain explicitly deferred.
+**Plans**: 3 plans
+
+Plans:
+- [ ] 05-01: Add PPU mode/dot/LY state machine skeleton
+- [ ] 05-02: Enforce VRAM/OAM access restrictions through Bus tests
+- [ ] 05-03: Connect PPU mode transitions to interrupt request hooks
+
+## Progress
+
+**Execution Order:**
+Phases execute in numeric order: 1 -> 2 -> 3 -> 4 -> 5
+
+| Phase | Plans Complete | Status | Completed |
+|-------|----------------|--------|-----------|
+| 1. Cartridge and Bus Foundation | 0/3 | Not started | - |
+| 2. CPU Core Foundation | 0/3 | Not started | - |
+| 3. Timer and Interrupt Foundations | 0/3 | Not started | - |
+| 4. Automated Validation Harness | 0/2 | Not started | - |
+| 5. PPU Mode Skeleton and Access Rules | 0/3 | Not started | - |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -12,7 +12,7 @@ GameGirl v1.0 turns the current Rust CLI scaffold into a testable DMG emulator c
 
 Decimal phases appear between their surrounding integers in numeric order.
 
-- [ ] **Phase 1: Cartridge and Bus Foundation** - Replace placeholder ROM text loading with binary cartridge parsing and a tested DMG Bus skeleton
+- [x] **Phase 1: Cartridge and Bus Foundation** - Replace placeholder ROM text loading with binary cartridge parsing and a tested DMG Bus skeleton
 - [ ] **Phase 2: CPU Core Foundation** - Add DMG CPU state, Bus-backed fetch/decode/execute flow, staged initial instruction groups, and cycle reporting
 - [ ] **Phase 2.1: Minimal Serial and ROM Test Harness INSERTED** - Run small ROM fixtures under deterministic limits and capture serial test output
 - [ ] **Phase 3: Timer and Interrupt Foundations** - Model timer registers, interrupt state, delayed `ei`, and interrupt service behavior
@@ -35,9 +35,9 @@ Decimal phases appear between their surrounding integers in numeric order.
 **Plans**: 3 plans
 
 Plans:
-- [ ] 01-01: Replace text ROM loading with binary cartridge loading and CLI errors
-- [ ] 01-02: Parse cartridge headers and model ROM-only cartridge reads
-- [ ] 01-03: Introduce Bus address routing with focused tests
+- [x] 01-01: Replace text ROM loading with binary cartridge loading and CLI errors
+- [x] 01-02: Parse cartridge headers and model ROM-only cartridge reads
+- [x] 01-03: Introduce Bus address routing with focused tests
 
 ### Phase 2: CPU Core Foundation
 **Goal**: Emulator has a DMG CPU core that fetches through the Bus, starts from documented post-boot state, executes initial instruction groups in staged slices, updates flags, and reports cycles.
@@ -132,8 +132,8 @@ Phases execute in numeric order: 1 -> 2 -> 2.1 -> 3 -> 4 -> 5
 
 | Phase | Plans Complete | Status | Completed |
 |-------|----------------|--------|-----------|
-| 1. Cartridge and Bus Foundation | 0/3 | Not started | - |
-| 2. CPU Core Foundation | 0/5 | Not started | - |
+| 1. Cartridge and Bus Foundation | 3/3 | Complete | 2026-05-02 |
+| 2. CPU Core Foundation | 0/5 | Ready to plan | - |
 | 2.1 Minimal Serial and ROM Test Harness INSERTED | 0/2 | Not started | - |
 | 3. Timer and Interrupt Foundations | 0/3 | Not started | - |
 | 4. Automated Validation Harness Expansion | 0/2 | Not started | - |

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,12 +1,14 @@
 ---
-gsd_state_version: "1.0"
-milestone: "v1.0"
-milestone_name: "Emulator Core Foundation"
+gsd_state_version: 1.0
+milestone: v1.0
+milestone_name: Emulator Core Foundation
 current_phase: 1
-current_phase_name: "Cartridge and Bus Foundation"
-status: "planning"
-last_updated: "2026-05-02T00:00:00.000Z"
-last_activity: "2026-05-02"
+current_phase_name: Cartridge and Bus Foundation
+current_plan: Not started
+status: planning
+stopped_at: Phase 1 context gathered
+last_updated: "2026-05-02T02:41:06.054Z"
+last_activity: 2026-05-02
 progress:
   total_phases: 5
   completed_phases: 0
@@ -43,6 +45,7 @@ Progress: [          ] 0%
 ## Performance Metrics
 
 **Velocity:**
+
 - Total plans completed: 0
 - Average duration: n/a
 - Total execution time: 0 hours
@@ -54,6 +57,7 @@ Progress: [          ] 0%
 | - | - | - | - |
 
 **Recent Trend:**
+
 - Last 5 plans: none
 - Trend: n/a
 
@@ -92,6 +96,6 @@ Items acknowledged and carried forward from initialization:
 
 ## Session Continuity
 
-Last session: 2026-05-02
-Stopped at: Project initialized; Phase 1 ready for discussion/planning
-Resume file: None
+Last session: 2026-05-02T02:41:06.051Z
+Stopped at: Phase 1 context gathered
+Resume file: .planning/phases/01-cartridge-and-bus-foundation/01-CONTEXT.md

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,19 +2,19 @@
 gsd_state_version: 1.0
 milestone: v1.0
 milestone_name: Emulator Core Foundation
-current_phase: 1
-current_phase_name: Cartridge and Bus Foundation
+current_phase: 2
+current_phase_name: CPU Core Foundation
 current_plan: Not started
-status: executing
-stopped_at: Completed 01-01-PLAN.md
-last_updated: "2026-05-02T02:57:15.463Z"
-last_activity: "2026-05-02 - Completed quick task 260502-gih: Incorporate roadmap feedback"
+status: ready_to_plan
+stopped_at: Completed Phase 1
+last_updated: "2026-05-02T03:09:32Z"
+last_activity: "2026-05-02 - Completed Phase 1: Cartridge and Bus Foundation"
 progress:
   total_phases: 6
-  completed_phases: 0
-  total_plans: 3
-  completed_plans: 1
-  percent: 33
+  completed_phases: 1
+  total_plans: 18
+  completed_plans: 3
+  percent: 17
 ---
 
 # Project State
@@ -24,29 +24,29 @@ progress:
 See: .planning/PROJECT.md (updated 2026-05-02)
 
 **Core value:** GameGirl must execute DMG Game Boy ROMs accurately enough that behavior is driven by hardware rules and verified by known test ROMs, not by ad hoc demo success.
-**Current focus:** Phase 1: Cartridge and Bus Foundation
+**Current focus:** Phase 2: CPU Core Foundation
 
 ## Current Position
 
-Current Phase: 1
-Current Phase Name: Cartridge and Bus Foundation
+Current Phase: 2
+Current Phase Name: CPU Core Foundation
 Total Phases: 6
 Current Plan: Not started
-Total Plans in Phase: 3
-Status: Ready to execute
-Last activity: 2026-05-02 - Completed quick task 260502-gih: Incorporate roadmap feedback
-Last Activity Description: Roadmap feedback inserted — early serial ROM harness added as Phase 2.1, CPU phase split into five plans, and v1 assumptions clarified
+Total Plans in Phase: 5
+Status: Ready to plan
+Last activity: 2026-05-02
+Last Activity Description: Phase 1 completed with binary cartridge loading, ROM-only cartridge metadata/reads, and Bus address routing verified; ready to discuss or plan Phase 2 CPU core foundation.
 
-Phase: 1 of 6 (Cartridge and Bus Foundation)
+Phase: 2 of 6 (CPU Core Foundation)
 Plan: Not started
 
-Progress: [          ] 0%
+Progress: [##        ] 17%
 
 ## Performance Metrics
 
 **Velocity:**
 
-- Total plans completed: 0
+- Total plans completed: 3
 - Average duration: n/a
 - Total execution time: 0 hours
 
@@ -54,15 +54,12 @@ Progress: [          ] 0%
 
 | Phase | Plans | Total | Avg/Plan |
 |-------|-------|-------|----------|
-| - | - | - | - |
+| 01 | 3 | - | - |
 
 **Recent Trend:**
 
-- Last 5 plans: none
-- Trend: n/a
-
-*Updated after each plan completion*
-| Phase 01 P01 | 3 min | 3 tasks | 3 files |
+- Last 5 plans: 01-01, 01-02, 01-03
+- Trend: Phase 1 complete; next work is Phase 2 planning
 
 ## Accumulated Context
 
@@ -81,7 +78,6 @@ None yet.
 
 ### Blockers/Concerns
 
-- Current `src/main.rs` reads ROMs as UTF-8 text; Phase 1 must replace this with binary reads.
 - GitHub Actions Rust workflow references a missing `git-check` step before formatting push logic.
 
 ### Quick Tasks Completed
@@ -103,6 +99,6 @@ Items acknowledged and carried forward from initialization:
 
 ## Session Continuity
 
-Last session: 2026-05-02T02:57:15.346Z
-Stopped at: Completed 01-01-PLAN.md
+Last session: 2026-05-02T03:09:32Z
+Stopped at: Completed Phase 1
 Resume file: None

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -5,10 +5,10 @@ milestone_name: Emulator Core Foundation
 current_phase: 1
 current_phase_name: Cartridge and Bus Foundation
 current_plan: Not started
-status: planning
+status: executing
 stopped_at: Phase 1 context gathered
-last_updated: "2026-05-02T02:41:06.054Z"
-last_activity: 2026-05-02
+last_updated: "2026-05-02T02:48:35.796Z"
+last_activity: 2026-05-02 -- Phase 01 planning complete
 progress:
   total_phases: 5
   completed_phases: 0
@@ -33,9 +33,9 @@ Current Phase Name: Cartridge and Bus Foundation
 Total Phases: 5
 Current Plan: Not started
 Total Plans in Phase: 3
-Status: Ready to plan
-Last Activity: 2026-05-02
-Last Activity Description: Project initialized and roadmap created
+Status: Ready to execute
+Last activity: 2026-05-02 -- Phase 01 planning complete
+Last Activity Description: Phase 01 planning complete — 3 plans ready
 
 Phase: 1 of 5 (Cartridge and Bus Foundation)
 Plan: Not started

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,0 +1,97 @@
+---
+gsd_state_version: "1.0"
+milestone: "v1.0"
+milestone_name: "Emulator Core Foundation"
+current_phase: 1
+current_phase_name: "Cartridge and Bus Foundation"
+status: "planning"
+last_updated: "2026-05-02T00:00:00.000Z"
+last_activity: "2026-05-02"
+progress:
+  total_phases: 5
+  completed_phases: 0
+  total_plans: 14
+  completed_plans: 0
+  percent: 0
+---
+
+# Project State
+
+## Project Reference
+
+See: .planning/PROJECT.md (updated 2026-05-02)
+
+**Core value:** GameGirl must execute DMG Game Boy ROMs accurately enough that behavior is driven by hardware rules and verified by known test ROMs, not by ad hoc demo success.
+**Current focus:** Phase 1: Cartridge and Bus Foundation
+
+## Current Position
+
+Current Phase: 1
+Current Phase Name: Cartridge and Bus Foundation
+Total Phases: 5
+Current Plan: Not started
+Total Plans in Phase: 3
+Status: Ready to plan
+Last Activity: 2026-05-02
+Last Activity Description: Project initialized and roadmap created
+
+Phase: 1 of 5 (Cartridge and Bus Foundation)
+Plan: Not started
+
+Progress: [          ] 0%
+
+## Performance Metrics
+
+**Velocity:**
+- Total plans completed: 0
+- Average duration: n/a
+- Total execution time: 0 hours
+
+**By Phase:**
+
+| Phase | Plans | Total | Avg/Plan |
+|-------|-------|-------|----------|
+| - | - | - | - |
+
+**Recent Trend:**
+- Last 5 plans: none
+- Trend: n/a
+
+*Updated after each plan completion*
+
+## Accumulated Context
+
+### Decisions
+
+Decisions are logged in PROJECT.md Key Decisions table.
+Recent decisions affecting current work:
+
+- Initialization: Brownfield codebase map was created before project setup.
+- Initialization: v1.0 is scoped to DMG emulator core foundations, not UI/audio/CGB.
+- Initialization: Bus-centered architecture and test-ROM-driven validation are guiding constraints.
+
+### Pending Todos
+
+None yet.
+
+### Blockers/Concerns
+
+- Current `src/main.rs` reads ROMs as UTF-8 text; Phase 1 must replace this with binary reads.
+- GitHub Actions Rust workflow references a missing `git-check` step before formatting push logic.
+
+## Deferred Items
+
+Items acknowledged and carried forward from initialization:
+
+| Category | Item | Status | Deferred At |
+|----------|------|--------|-------------|
+| Rendering | Full pixel rendering | Deferred to v2 requirements | v1.0 initialization |
+| Audio | APU and host audio output | Deferred to v2 requirements | v1.0 initialization |
+| Compatibility | CGB behavior | Deferred to v2 requirements | v1.0 initialization |
+| Host | Desktop UI | Deferred to v2 requirements | v1.0 initialization |
+
+## Session Continuity
+
+Last session: 2026-05-02
+Stopped at: Project initialized; Phase 1 ready for discussion/planning
+Resume file: None

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -6,15 +6,15 @@ current_phase: 1
 current_phase_name: Cartridge and Bus Foundation
 current_plan: Not started
 status: executing
-stopped_at: Phase 1 context gathered
-last_updated: "2026-05-02T02:48:35.796Z"
-last_activity: 2026-05-02 -- Phase 01 planning complete
+stopped_at: Completed 01-01-PLAN.md
+last_updated: "2026-05-02T02:57:15.463Z"
+last_activity: "2026-05-02 - Completed quick task 260502-gih: Incorporate roadmap feedback"
 progress:
-  total_phases: 5
+  total_phases: 6
   completed_phases: 0
-  total_plans: 14
-  completed_plans: 0
-  percent: 0
+  total_plans: 3
+  completed_plans: 1
+  percent: 33
 ---
 
 # Project State
@@ -30,14 +30,14 @@ See: .planning/PROJECT.md (updated 2026-05-02)
 
 Current Phase: 1
 Current Phase Name: Cartridge and Bus Foundation
-Total Phases: 5
+Total Phases: 6
 Current Plan: Not started
 Total Plans in Phase: 3
 Status: Ready to execute
-Last activity: 2026-05-02 -- Phase 01 planning complete
-Last Activity Description: Phase 01 planning complete — 3 plans ready
+Last activity: 2026-05-02 - Completed quick task 260502-gih: Incorporate roadmap feedback
+Last Activity Description: Roadmap feedback inserted — early serial ROM harness added as Phase 2.1, CPU phase split into five plans, and v1 assumptions clarified
 
-Phase: 1 of 5 (Cartridge and Bus Foundation)
+Phase: 1 of 6 (Cartridge and Bus Foundation)
 Plan: Not started
 
 Progress: [          ] 0%
@@ -62,6 +62,7 @@ Progress: [          ] 0%
 - Trend: n/a
 
 *Updated after each plan completion*
+| Phase 01 P01 | 3 min | 3 tasks | 3 files |
 
 ## Accumulated Context
 
@@ -83,6 +84,12 @@ None yet.
 - Current `src/main.rs` reads ROMs as UTF-8 text; Phase 1 must replace this with binary reads.
 - GitHub Actions Rust workflow references a missing `git-check` step before formatting push logic.
 
+### Quick Tasks Completed
+
+| # | Description | Date | Commit | Directory |
+|---|-------------|------|--------|-----------|
+| 260502-gih | Incorporate roadmap feedback: insert early minimal serial ROM validation harness, narrow CPU phase scope, and clarify ROM-only/MBC and post-boot assumptions | 2026-05-02 | docs-only | [260502-gih-incorporate-roadmap-feedback-insert-earl](./quick/260502-gih-incorporate-roadmap-feedback-insert-earl/) |
+
 ## Deferred Items
 
 Items acknowledged and carried forward from initialization:
@@ -96,6 +103,6 @@ Items acknowledged and carried forward from initialization:
 
 ## Session Continuity
 
-Last session: 2026-05-02T02:41:06.051Z
-Stopped at: Phase 1 context gathered
-Resume file: .planning/phases/01-cartridge-and-bus-foundation/01-CONTEXT.md
+Last session: 2026-05-02T02:57:15.346Z
+Stopped at: Completed 01-01-PLAN.md
+Resume file: None

--- a/.planning/codebase/ARCHITECTURE.md
+++ b/.planning/codebase/ARCHITECTURE.md
@@ -1,0 +1,123 @@
+# Architecture
+
+**Analysis Date:** 2026-05-02
+
+## Pattern Overview
+
+**Overall:** Early-stage Rust CLI prototype for a Game Boy emulator.
+
+**Key Characteristics:**
+- Single binary crate.
+- Single source file: `src/main.rs`.
+- No emulator domain modules have been implemented yet.
+- Documentation already describes the intended emulator architecture and implementation roadmap.
+- ROM fixtures are present for later validation, but they are not wired into automated tests.
+
+## Layers
+
+**CLI Boundary:**
+- Purpose: Accept command-line input and report usage/errors to the user.
+- Contains: argument collection, extension validation, console output.
+- Location: `src/main.rs`.
+- Depends on: Rust standard library only.
+- Used by: direct binary execution through Cargo or compiled executable.
+
+**Prototype File Loading:**
+- Purpose: Load the supplied ROM path.
+- Contains: a call to `fs::read_to_string`.
+- Location: `src/main.rs`.
+- Depends on: local filesystem.
+- Used by: CLI boundary after extension validation.
+
+**Planned Emulator Core:**
+- Purpose: Eventually model Game Boy hardware behavior.
+- Contains: not implemented yet.
+- Intended components from `docs/hot_to_proceed.md` and `docs/gameboy_architecture_summary.md`:
+  - Bus and memory map.
+  - CPU registers, fetch/decode/execute loop, and LR35902 instructions.
+  - Timer and interrupt controller.
+  - PPU mode timing, VRAM/OAM access restrictions, background/window/sprite rendering.
+  - Joypad input.
+  - Cartridge and MBC support.
+  - APU audio channels.
+
+## Data Flow
+
+**Current CLI Execution:**
+
+1. User runs the binary with a ROM path argument.
+2. `src/main.rs` collects all command-line arguments with `env::args()`.
+3. If no ROM path is supplied, the program prints usage to stderr and returns.
+4. If the path does not end with `.gb` or `.gbc`, the program prints an error and returns.
+5. The program reads the path as UTF-8 text using `fs::read_to_string`.
+6. The loaded text is printed to stdout.
+
+**Planned Emulator Execution:**
+
+1. Load cartridge bytes from a `.gb` or `.gbc` file.
+2. Parse cartridge header and determine ROM/MBC behavior.
+3. Initialize DMG CPU registers and memory-mapped devices.
+4. Step CPU instructions through a bus that coordinates memory, timer, interrupts, PPU, joypad, and cartridge access.
+5. Use test ROMs to verify instruction correctness and timing.
+
+**State Management:**
+- Current application state is local to `main`.
+- Planned emulator state should be explicit structs for CPU registers, bus, memory, cartridge, timer, PPU, joypad, and later APU.
+- No persistence is implemented yet.
+
+## Key Abstractions
+
+**CLI Program:**
+- Purpose: Minimal command runner.
+- Example: `src/main.rs`.
+- Pattern: single `main()` function.
+
+**Bus (planned):**
+- Purpose: Centralize 16-bit address / 8-bit data reads and writes across CPU-visible devices.
+- Examples: none implemented.
+- Pattern: should become the boundary between CPU and devices.
+
+**CPU (planned):**
+- Purpose: Implement LR35902 registers, instruction decode, execution, flags, and timing.
+- Examples: none implemented.
+- Pattern: likely `Cpu` struct plus opcode execution helpers.
+
+**Cartridge (planned):**
+- Purpose: Hold ROM bytes, parse header metadata, and provide MBC behavior.
+- Examples: none implemented.
+- Pattern: trait or enum-backed mapper implementations may fit future MBC0/MBC1/MBC3/MBC5 support.
+
+## Entry Points
+
+**CLI Entry:**
+- Location: `src/main.rs`.
+- Triggers: user runs the binary through Cargo or direct executable invocation.
+- Responsibilities: validate arguments, read supplied file, print result.
+
+## Error Handling
+
+**Strategy:** Early returns for expected argument/extension failures, panic for read failures.
+
+**Patterns:**
+- `eprintln!` for missing-argument usage.
+- `println!` for invalid extension.
+- `expect("Something went wrong reading the file")` for read failures.
+
+## Cross-Cutting Concerns
+
+**Logging:**
+- Console output only.
+- No structured logging or log levels.
+
+**Validation:**
+- Simple filename suffix check for `.gb` and `.gbc`.
+- No binary header validation yet.
+
+**Testing:**
+- No source-level tests currently exist.
+- Future emulator behavior should be validated against checked-in blargg and mooneye ROMs.
+
+---
+
+*Architecture analysis: 2026-05-02*
+*Update when major patterns change*

--- a/.planning/codebase/CONCERNS.md
+++ b/.planning/codebase/CONCERNS.md
@@ -1,0 +1,148 @@
+# Codebase Concerns
+
+**Analysis Date:** 2026-05-02
+
+## Tech Debt
+
+**Single-file prototype:**
+- Issue: All runtime logic is in `src/main.rs`.
+- Why: The project is at the scaffold/prototype stage.
+- Impact: No natural place yet for emulator concepts such as CPU, Bus, Cartridge, Timer, PPU, Joypad, or APU.
+- Fix approach: Introduce small Rust modules as each emulator subsystem is implemented.
+
+**ROM loading reads binary files as text:**
+- Issue: `src/main.rs` uses `fs::read_to_string(file_path)`.
+- Why: Placeholder CLI behavior.
+- Impact: Real `.gb` and `.gbc` files are binary and may fail UTF-8 parsing or be corrupted conceptually by text handling.
+- Fix approach: Replace with `fs::read(file_path)` and pass raw bytes into a cartridge loader.
+
+**Extension check only:**
+- Issue: Valid input is checked only by `.gb` or `.gbc` suffix.
+- Why: Minimal placeholder validation.
+- Impact: Invalid files with matching suffix pass the boundary; valid uppercase or unusual paths may be rejected.
+- Fix approach: Validate readable bytes, minimum header length, Nintendo logo/header fields where appropriate, and cartridge type.
+
+## Known Bugs
+
+**Binary ROM read failure:**
+- Symptoms: Many ROMs will panic with "Something went wrong reading the file" if their bytes are not valid UTF-8.
+- Trigger: Run the current binary against a normal binary ROM, for example a file under `roms/blargg-gb-tests/`.
+- Workaround: None in current code.
+- Root cause: `fs::read_to_string` instead of `fs::read`.
+
+**CI format workflow references missing step id:**
+- Symptoms: `.github/workflows/rust.yml` has `if: steps.git-check.outputs.modified == 'true'`, but no `git-check` step is defined.
+- Trigger: GitHub Actions evaluates the "push changes" step.
+- Workaround: The condition likely evaluates false or the workflow fails depending on Actions expression handling.
+- Root cause: Missing git diff/check step before attempting to push formatting changes.
+
+## Security Considerations
+
+**Untrusted ROM input:**
+- Risk: Emulator will eventually parse arbitrary binary data.
+- Current mitigation: Only a suffix check exists.
+- Recommendations: Treat ROM files as untrusted input, avoid unsafe Rust unless absolutely necessary, check bounds before indexing, and fuzz parsers once cartridge loading exists.
+
+**CI token usage in formatting workflow:**
+- Risk: `.github/workflows/rust.yml` rewrites origin with `secrets.GITHUB_TOKEN` in a shell command to push formatting changes.
+- Current mitigation: GitHub masks secrets in logs, but the step is currently gated by a missing step id.
+- Recommendations: Prefer a dedicated formatting check that fails on unformatted code, or use a well-maintained formatting action with least privilege.
+
+## Performance Bottlenecks
+
+**No emulator loop yet:**
+- Problem: There are no measured performance bottlenecks because core emulation is not implemented.
+- Measurement: Not available.
+- Cause: Project is still scaffold-level.
+- Improvement path: Once CPU stepping exists, add benchmarks around instruction execution and frame timing before optimizing.
+
+**Future ROM loading:**
+- Problem: Current text loading would be incorrect and inefficient for binary ROM data.
+- Measurement: Not measured.
+- Cause: Placeholder file read path.
+- Improvement path: Use byte loading and avoid repeated copies when introducing cartridge parsing.
+
+## Fragile Areas
+
+**Future CPU flags and timing:**
+- Why fragile: Game Boy behavior depends on exact `Z/N/H/C` flags, delayed `ei`, HALT behavior, interrupt timing, and instruction cycles.
+- Common failures: Passing simple demos while failing blargg/mooneye edge cases.
+- Safe modification: Implement instructions in small groups with unit tests and ROM tests.
+- Test coverage: No emulator tests exist yet.
+
+**Future Timer implementation:**
+- Why fragile: `DIV`, `TIMA`, `TMA`, and `TAC` depend on internal counter bits and falling-edge behavior.
+- Common failures: Incorrect reload timing and missed timer interrupt edge cases.
+- Safe modification: Model an internal system counter from the start.
+- Test coverage: ROM fixtures exist under `roms/mooneye/acceptance/timer/`, but no harness exists.
+
+**Future PPU access restrictions:**
+- Why fragile: VRAM/OAM access depends on PPU mode timing.
+- Common failures: Rendering works in simple cases but fails timing tests or sprite/OAM edge cases.
+- Safe modification: Introduce PPU mode state before full rendering so bus access rules have a home.
+- Test coverage: PPU acceptance ROMs exist under `roms/mooneye/acceptance/ppu/`, but no harness exists.
+
+## Scaling Limits
+
+**Repository size and ROM fixtures:**
+- Current capacity: Many binary fixtures are checked into `roms/`.
+- Limit: Repository clone size and CI checkout time may grow if more ROM suites are added.
+- Symptoms at limit: Slow checkouts and storage churn.
+- Scaling path: Keep only legally safe, high-value fixtures in git; document optional external suites if needed.
+
+## Dependencies at Risk
+
+**actions-rs GitHub Actions:**
+- Risk: `.github/workflows/rust.yml` and `.github/workflows/rust-clippy.yml` use `actions-rs` actions, which have seen limited maintenance.
+- Impact: CI may break as GitHub runner/toolchain behavior changes.
+- Migration plan: Use `dtolnay/rust-toolchain` or direct `rustup`/`cargo` commands.
+
+**Dependabot Go module configuration:**
+- Risk: `.github/dependabot.yml` includes `package-ecosystem: "gomod"` at `/`, but the repo currently has no `go.mod`.
+- Impact: No useful Go updates; potential confusion in dependency automation.
+- Migration plan: Remove the gomod entry unless a Go component is introduced.
+
+## Missing Critical Features
+
+**Cartridge byte loader:**
+- Problem: No binary ROM loader or cartridge header parser exists.
+- Current workaround: None.
+- Blocks: Any real emulator behavior.
+- Implementation complexity: Low for MBC0/header basics, higher for MBC variants.
+
+**CPU core:**
+- Problem: No registers, fetch/decode/execute loop, instruction set, or timing model exists.
+- Current workaround: None.
+- Blocks: All emulator execution.
+- Implementation complexity: High but can be phased by instruction groups.
+
+**Bus and memory map:**
+- Problem: No address map or read/write interface exists.
+- Current workaround: None.
+- Blocks: CPU, cartridge, timer, PPU, joypad, and interrupt integration.
+- Implementation complexity: Medium.
+
+**Automated ROM test harness:**
+- Problem: Validation ROMs are present but not executable through tests.
+- Current workaround: Manual future use.
+- Blocks: Confidence in CPU/timing/hardware compatibility.
+- Implementation complexity: Medium.
+
+## Test Coverage Gaps
+
+**All emulator behavior:**
+- What's not tested: CPU, bus, cartridge, timer, interrupts, PPU, joypad, APU.
+- Risk: Core correctness regressions will go unnoticed once implementation begins.
+- Priority: High.
+- Difficulty to test: Requires emulator harness design and pass/fail detection for ROM suites.
+
+**CLI input behavior:**
+- What's not tested: missing argument, invalid extension, unreadable file, binary ROM loading.
+- Risk: Regressions at the only current runtime boundary.
+- Priority: Medium.
+- Difficulty to test: Low.
+
+---
+
+*Concerns audit: 2026-05-02*
+*Update as issues are fixed or new ones discovered*

--- a/.planning/codebase/CONVENTIONS.md
+++ b/.planning/codebase/CONVENTIONS.md
@@ -1,0 +1,113 @@
+# Coding Conventions
+
+**Analysis Date:** 2026-05-02
+
+## Naming Patterns
+
+**Files:**
+- Rust files should use snake_case, matching standard Rust conventions.
+- Current source file is `src/main.rs`.
+- Future emulator modules should use focused names such as `cpu.rs`, `bus.rs`, `cartridge.rs`, `timer.rs`, and `ppu.rs`.
+
+**Functions:**
+- Rust functions use snake_case.
+- Current executable uses a single `main()` function.
+
+**Variables:**
+- Rust local variables use snake_case, as seen with `args`, `file_path`, and `contents` in `src/main.rs`.
+- Constants are not present yet; use UPPER_SNAKE_CASE for future compile-time constants.
+
+**Types:**
+- No project types are defined yet.
+- Future structs/enums should use PascalCase, matching Rust convention.
+
+## Code Style
+
+**Formatting:**
+- rustfmt is the expected formatter.
+- CI runs `cargo fmt --all` in `.github/workflows/rust.yml`.
+- Indentation and formatting should follow Rust defaults.
+
+**Linting:**
+- Clippy is expected.
+- CI runs `cargo clippy` in `.github/workflows/rust.yml`.
+- A separate clippy SARIF workflow exists at `.github/workflows/rust-clippy.yml`.
+
+## Import Organization
+
+**Order:**
+1. Standard library imports.
+2. External crate imports, once dependencies are added.
+3. Internal module imports.
+
+**Grouping:**
+- Current code groups `std::env` and `std::fs` together at the top of `src/main.rs`.
+- Keep imports simple and explicit.
+
+**Path Aliases:**
+- None.
+
+## Error Handling
+
+**Patterns:**
+- Current code uses early return for missing arguments and invalid extensions.
+- Current code panics on file read failure through `expect`.
+- As emulator code grows, prefer returning `Result` from parsing/loading helpers so CLI boundaries can format errors without panics.
+
+**Error Types:**
+- None defined yet.
+- Future cartridge loading should distinguish invalid path, unsupported extension, unreadable file, invalid header, and unsupported MBC.
+
+## Logging
+
+**Framework:**
+- `println!` and `eprintln!` only.
+
+**Patterns:**
+- Use `eprintln!` for usage and errors.
+- Keep emulator core free of console output; return structured results/errors to the boundary instead.
+
+## Comments
+
+**When to Comment:**
+- Explain hardware quirks, timing assumptions, and spec/test-ROM discrepancies.
+- Good candidates include DAA flag behavior, timer falling-edge behavior, delayed `ei`, HALT behavior, and PPU access restrictions.
+- Avoid comments that merely restate straightforward Rust statements.
+
+**Rustdoc:**
+- Not used yet.
+- Add Rustdoc for public emulator structs, especially if a `lib.rs` is introduced.
+
+**TODO Comments:**
+- No project TODO pattern is established.
+- Prefer tracking planned work in `.planning/` requirements and phase plans once initialization is complete.
+
+## Function Design
+
+**Size:**
+- `main()` is currently short.
+- Future instruction and device logic should be split into small helpers because emulator correctness depends on many edge cases.
+
+**Parameters:**
+- Prefer typed structs over long parameter lists for hardware state.
+- Keep CPU/device state ownership explicit.
+
+**Return Values:**
+- Prefer `Result<T, E>` for fallible loading/parsing.
+- Avoid hidden panics in emulator core code.
+
+## Module Design
+
+**Exports:**
+- No module export pattern exists yet.
+- If the project grows past a single binary, introduce `src/lib.rs` for reusable emulator core and keep `src/main.rs` as a CLI shell.
+
+**Boundaries:**
+- Keep CPU instruction execution independent from cartridge file I/O.
+- Route memory-mapped reads/writes through a Bus abstraction.
+- Keep rendering/audio backends separate from timing-accurate PPU/APU state.
+
+---
+
+*Convention analysis: 2026-05-02*
+*Update when patterns change*

--- a/.planning/codebase/INTEGRATIONS.md
+++ b/.planning/codebase/INTEGRATIONS.md
@@ -1,0 +1,86 @@
+# External Integrations
+
+**Analysis Date:** 2026-05-02
+
+## APIs & External Services
+
+**Runtime Services:**
+- None. `src/main.rs` performs local argument parsing and local file reads only.
+
+**External APIs:**
+- None used by the application code.
+
+## Data Storage
+
+**Databases:**
+- None.
+
+**File Storage:**
+- Local filesystem only.
+  - `src/main.rs` expects a local `.gb` or `.gbc` path as its first argument.
+  - Current implementation reads the file with `fs::read_to_string`, which is not suitable for binary ROM data.
+
+**Caching:**
+- None.
+
+## Authentication & Identity
+
+**Auth Provider:**
+- None.
+
+**OAuth Integrations:**
+- None.
+
+## Monitoring & Observability
+
+**Error Tracking:**
+- None.
+
+**Analytics:**
+- None.
+
+**Logs:**
+- Console output only through `println!` and `eprintln!` in `src/main.rs`.
+
+## CI/CD & Repository Automation
+
+**Hosting:**
+- GitHub repository metadata is configured in `Cargo.toml` as `https://github.com/smirror/GameGirl`.
+
+**CI Pipeline:**
+- GitHub Actions:
+  - `.github/workflows/rust.yml` runs formatting, clippy, and tests for Rust source changes.
+  - `.github/workflows/rust-clippy.yml` runs scheduled and PR/push clippy SARIF analysis.
+  - `.github/workflows/dependency-review.yml` runs dependency review on pull requests.
+  - `.github/workflows/label.yml` labels pull requests using `.github/labeler.yml`.
+  - `.github/workflows/assign.yml` adds reviewers using `.github/auto_assign.yml`.
+  - `.github/workflows/greetings.yml` posts first interaction messages.
+- Dependabot:
+  - `.github/dependabot.yml` tracks GitHub Actions weekly.
+  - It also configures a Go module ecosystem at `/`, although this repository currently has no `go.mod`.
+
+## Environment Configuration
+
+**Development:**
+- Required env vars: none.
+- Secrets location: none required by application code.
+- Test fixtures: ROMs are checked into `roms/`.
+
+**Staging:**
+- Not defined.
+
+**Production:**
+- Not defined.
+
+## Webhooks & Callbacks
+
+**Incoming:**
+- None.
+
+**Outgoing:**
+- None.
+
+---
+
+*Integration audit: 2026-05-02*
+*Update when adding/removing external services*

--- a/.planning/codebase/STACK.md
+++ b/.planning/codebase/STACK.md
@@ -1,0 +1,73 @@
+# Technology Stack
+
+**Analysis Date:** 2026-05-02
+
+## Languages
+
+**Primary:**
+- Rust 2021 edition - all executable application code currently lives in `src/main.rs`.
+
+**Secondary:**
+- Markdown - project documentation in `README.md`, `docs/hot_to_proceed.md`, `docs/gameboy_architecture_summary.md`, and ROM notes.
+- Game Boy assembly - sample and upstream test ROM sources under `roms/**/source/` and `roms/hello-world/hello-world.asm`.
+- YAML - GitHub Actions and repository automation under `.github/`.
+
+## Runtime
+
+**Environment:**
+- Native Rust binary built with Cargo.
+- No explicit minimum Rust toolchain is pinned in `Cargo.toml`, `rust-toolchain.toml`, or `.github/`.
+- CI installs the stable Rust toolchain in `.github/workflows/rust-clippy.yml`.
+
+**Package Manager:**
+- Cargo - package metadata in `Cargo.toml`.
+- Lockfile: `Cargo.lock` is present.
+
+## Frameworks
+
+**Core:**
+- None. The current crate uses only Rust standard library APIs.
+
+**Testing:**
+- Cargo test harness - invoked by `.github/workflows/rust.yml`.
+- External ROM fixtures - `roms/blargg-gb-tests/`, `roms/mooneye/`, and `roms/hello-world/` provide future emulator validation assets, but no automated harness consumes them yet.
+
+**Build/Dev:**
+- Cargo - build, format, lint, and test commands.
+- rustfmt - run in `.github/workflows/rust.yml` through `cargo fmt --all`.
+- Clippy - run in `.github/workflows/rust.yml` and SARIF-producing `.github/workflows/rust-clippy.yml`.
+
+## Key Dependencies
+
+**Critical:**
+- Rust standard library - `std::env` for CLI argument collection and `std::fs` for file reading in `src/main.rs`.
+
+**Infrastructure:**
+- GitHub Actions - CI, labeling, first-interaction greeting, dependency review, auto-assignment, and clippy SARIF upload.
+- No crates are listed in `[dependencies]` in `Cargo.toml`.
+
+## Configuration
+
+**Environment:**
+- No application environment variables are required.
+- Runtime configuration is currently only the first CLI argument: a path ending in `.gb` or `.gbc`.
+
+**Build:**
+- `Cargo.toml` - Rust package metadata.
+- `Cargo.lock` - dependency lockfile.
+- `.editorconfig` - editor formatting baseline.
+- `.github/workflows/*.yml` - CI automation.
+
+## Platform Requirements
+
+**Development:**
+- Any platform with a compatible Rust toolchain and Cargo.
+- No external database, service, or local daemon is required.
+
+**Production:**
+- Not defined yet. The package metadata describes "A GameBoy emulator written in Rust", but the current executable is only a prototype CLI.
+
+---
+
+*Stack analysis: 2026-05-02*
+*Update after major dependency or runtime changes*

--- a/.planning/codebase/STRUCTURE.md
+++ b/.planning/codebase/STRUCTURE.md
@@ -1,0 +1,141 @@
+# Codebase Structure
+
+**Analysis Date:** 2026-05-02
+
+## Directory Layout
+
+```text
+GameGirl/
+|-- .github/             # GitHub automation, CI, labels, dependabot
+|-- docs/                # Design notes and Game Boy implementation research
+|-- roms/                # Sample and validation ROMs plus upstream test sources
+|-- src/                 # Rust application source
+|-- target/              # Cargo build output, local/generated
+|-- Cargo.toml           # Rust package manifest
+|-- Cargo.lock           # Cargo lockfile
+|-- README.md            # Project references and resource links
+|-- LICENSE              # MIT license
+`-- renovate.json        # Renovate configuration
+```
+
+## Directory Purposes
+
+**src/:**
+- Purpose: Rust application source.
+- Contains: currently only `src/main.rs`.
+- Key files: `src/main.rs` - CLI prototype.
+- Subdirectories: none.
+
+**docs/:**
+- Purpose: Project-specific implementation notes.
+- Contains: roadmap and Game Boy architecture summary.
+- Key files:
+  - `docs/hot_to_proceed.md` - Japanese implementation roadmap and resource guide.
+  - `docs/gameboy_architecture_summary.md` - DMG-focused hardware behavior summary.
+- Subdirectories: none.
+
+**roms/:**
+- Purpose: Local ROM fixtures and upstream emulator test suites.
+- Contains: sample hello-world ROM, blargg tests, mooneye tests.
+- Key files:
+  - `roms/hello-world/hello-world.gb` - simple sample ROM.
+  - `roms/blargg-gb-tests/cpu_instrs/cpu_instrs.gb` - CPU instruction validation ROM.
+  - `roms/mooneye/acceptance/` - timing and hardware acceptance tests.
+- Subdirectories: grouped by source/test suite and test category.
+
+**.github/:**
+- Purpose: Repository automation.
+- Contains: workflows, labeler config, auto-assign config, dependabot config.
+- Key files:
+  - `.github/workflows/rust.yml` - Rust format, clippy, and tests.
+  - `.github/workflows/rust-clippy.yml` - clippy SARIF upload workflow.
+  - `.github/dependabot.yml` - dependency update configuration.
+
+**target/:**
+- Purpose: Cargo build artifacts.
+- Contains: compiler outputs.
+- Committed: should remain untracked; it is a generated directory.
+
+## Key File Locations
+
+**Entry Points:**
+- `src/main.rs` - binary crate entry point.
+
+**Configuration:**
+- `Cargo.toml` - package metadata and dependencies.
+- `Cargo.lock` - locked dependency graph.
+- `.editorconfig` - editor formatting defaults.
+- `.github/workflows/*.yml` - CI behavior.
+- `renovate.json` - Renovate configuration.
+
+**Core Logic:**
+- `src/main.rs` - all current runtime logic.
+
+**Testing:**
+- `roms/blargg-gb-tests/` - CPU, timing, sound, memory, and OAM validation ROMs.
+- `roms/mooneye/` - acceptance, emulator-only, manual-only, and utility ROMs.
+- No Rust test files are currently present.
+
+**Documentation:**
+- `README.md` - external documentation and implementation references.
+- `docs/hot_to_proceed.md` - local implementation roadmap.
+- `docs/gameboy_architecture_summary.md` - local hardware behavior summary.
+- `roms/README.md` and nested ROM readmes - test fixture context.
+
+## Naming Conventions
+
+**Files:**
+- Rust source: `snake_case.rs`, currently `main.rs`.
+- Markdown docs: descriptive lowercase names in `docs/`; uppercase for root `README.md` and `LICENSE`.
+- ROM fixtures: preserve upstream filenames, including spaces and hardware suffixes where present.
+
+**Directories:**
+- Source directories are short lowercase names: `src`, `docs`, `roms`.
+- ROM directories preserve upstream suite/category names.
+
+**Special Patterns:**
+- `.gb` and `.gbc` are runtime ROM input formats.
+- `.sym` files accompany many test ROMs.
+- `.asm` and `.s` files are assembly sources for sample/test ROMs.
+
+## Where to Add New Code
+
+**New Emulator Module:**
+- Primary code: create focused Rust modules under `src/`, for example `src/bus.rs`, `src/cpu.rs`, `src/cartridge.rs`, `src/timer.rs`, `src/ppu.rs`.
+- Module wiring: declare modules from `src/main.rs` or a future `src/lib.rs`.
+- Tests: add unit tests inside each module or integration tests under a new `tests/` directory.
+
+**New CLI Behavior:**
+- Implementation: `src/main.rs` until CLI logic becomes large enough to extract.
+- Tests: integration tests can invoke the binary once behavior is stable.
+
+**New Test Harness:**
+- Implementation: likely `tests/` for integration tests and helper utilities.
+- Fixtures: use existing ROMs under `roms/`; avoid duplicating large ROM assets.
+
+**New Documentation:**
+- Project implementation notes: `docs/`.
+- GSD planning docs: `.planning/`.
+
+## Special Directories
+
+**roms/:**
+- Purpose: checked-in emulator validation assets.
+- Source: sample code plus upstream test suites.
+- Committed: yes.
+- Caution: contains many binary files and upstream naming conventions; preserve paths.
+
+**target/:**
+- Purpose: generated Cargo build artifacts.
+- Source: `cargo build`, `cargo test`, and other Cargo commands.
+- Committed: no.
+
+**.planning/:**
+- Purpose: GSD planning state and codebase maps.
+- Source: generated by GSD workflows.
+- Committed: yes if `commit_docs` remains enabled.
+
+---
+
+*Structure analysis: 2026-05-02*
+*Update when directory structure changes*

--- a/.planning/codebase/TESTING.md
+++ b/.planning/codebase/TESTING.md
@@ -1,0 +1,161 @@
+# Testing Patterns
+
+**Analysis Date:** 2026-05-02
+
+## Test Framework
+
+**Runner:**
+- Cargo test harness.
+- No additional Rust testing crates are configured.
+
+**Assertion Library:**
+- Rust built-in test assertions, when tests are added.
+- No custom matchers or snapshot tools are present.
+
+**Run Commands:**
+
+```bash
+cargo test --verbose     # Run all tests, matching CI
+cargo test               # Run all tests locally
+cargo fmt --all          # Format Rust code
+cargo clippy             # Run clippy locally
+cargo build              # Build the binary
+```
+
+## Test File Organization
+
+**Location:**
+- No Rust tests are currently present.
+- Future unit tests can live in `#[cfg(test)]` modules inside source files.
+- Future integration tests can live under `tests/`.
+
+**Naming:**
+- Use Rust defaults: module unit tests inline, integration test files as `tests/<feature>.rs`.
+- For ROM harness tests, use descriptive names such as `tests/blargg_cpu_instrs.rs` or `tests/mooneye_timer.rs`.
+
+**Structure:**
+
+```text
+src/
+  main.rs
+tests/
+  blargg_cpu_instrs.rs        # future integration harness
+  mooneye_acceptance.rs       # future integration harness
+roms/
+  blargg-gb-tests/
+  mooneye/
+```
+
+## Test Structure
+
+**Suite Organization:**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn describes_expected_behavior() {
+        // arrange
+        // act
+        // assert
+    }
+}
+```
+
+**Patterns:**
+- Use small unit tests for pure CPU flag/register helpers.
+- Use ROM-driven integration tests for instruction behavior, timing, and hardware interactions.
+- Keep fixtures in `roms/` rather than embedding binary blobs into test source.
+
+## Mocking
+
+**Framework:**
+- None configured.
+
+**Patterns:**
+- Prefer deterministic fake devices or in-memory cartridge data over mocking libraries.
+- Build tests around explicit CPU/bus/device state.
+
+**What to Mock:**
+- Future display/audio output adapters.
+- Future host input sources.
+- File I/O at the CLI boundary.
+
+**What NOT to Mock:**
+- CPU instruction execution.
+- Timer edge behavior.
+- Bus memory mapping.
+- Cartridge mapper behavior once implemented.
+
+## Fixtures and Factories
+
+**Test Data:**
+- `roms/hello-world/hello-world.gb` - simple sample ROM.
+- `roms/blargg-gb-tests/cpu_instrs/` - CPU instruction validation.
+- `roms/blargg-gb-tests/instr_timing/` - instruction timing validation.
+- `roms/blargg-gb-tests/mem_timing/` and `mem_timing-2/` - memory timing validation.
+- `roms/mooneye/acceptance/` - acceptance tests for CPU, timer, interrupt, PPU, DMA, and boot behavior.
+- `roms/mooneye/emulator-only/mbc*/` - MBC behavior tests.
+
+**Location:**
+- Shared ROM fixtures are already checked into `roms/`.
+- Future factory helpers can live in `tests/common/` or module-local test helpers.
+
+## Coverage
+
+**Requirements:**
+- No coverage target is defined.
+- CI currently blocks on `cargo test` failures but does not enforce coverage.
+
+**Configuration:**
+- No coverage tooling configured.
+
+**View Coverage:**
+- Not available until a coverage tool such as cargo-llvm-cov is added.
+
+## Test Types
+
+**Unit Tests:**
+- Scope: CPU register operations, flag helpers, instruction implementations, timer counters, memory map behavior.
+- Mocking: prefer direct state setup.
+- Speed: should be fast and deterministic.
+
+**Integration Tests:**
+- Scope: executing test ROMs until pass/fail output or known completion states.
+- Fixtures: blargg and mooneye ROMs under `roms/`.
+- Setup: future harness must define timeouts and pass/fail detection.
+
+**E2E Tests:**
+- None yet.
+- Future emulator UI/audio workflows would require separate host-level tests.
+
+## Common Patterns
+
+**Error Testing:**
+
+```rust
+#[test]
+fn rejects_invalid_cartridge_header() {
+    let rom = vec![0; 0x150];
+    let result = Cartridge::from_bytes(rom);
+    assert!(result.is_err());
+}
+```
+
+**ROM Testing:**
+
+```rust
+#[test]
+fn blargg_cpu_instrs_passes() {
+    // Load `roms/blargg-gb-tests/cpu_instrs/cpu_instrs.gb`.
+    // Run emulator until serial pass/fail output or timeout.
+    // Assert pass marker.
+}
+```
+
+---
+
+*Testing analysis: 2026-05-02*
+*Update when test patterns change*

--- a/.planning/config.json
+++ b/.planning/config.json
@@ -1,0 +1,42 @@
+{
+  "model_profile": "balanced",
+  "commit_docs": true,
+  "parallelization": true,
+  "search_gitignored": false,
+  "brave_search": false,
+  "firecrawl": false,
+  "exa_search": false,
+  "git": {
+    "branching_strategy": "none",
+    "phase_branch_template": "gsd/phase-{phase}-{slug}",
+    "milestone_branch_template": "gsd/{milestone}-{slug}",
+    "quick_branch_template": null
+  },
+  "workflow": {
+    "research": true,
+    "plan_check": true,
+    "verifier": true,
+    "nyquist_validation": false,
+    "auto_advance": false,
+    "node_repair": true,
+    "node_repair_budget": 2,
+    "ui_phase": true,
+    "ui_safety_gate": true,
+    "text_mode": false,
+    "research_before_questions": false,
+    "discuss_mode": "discuss",
+    "skip_discuss": false,
+    "code_review": true,
+    "code_review_depth": "standard"
+  },
+  "hooks": {
+    "context_warnings": true
+  },
+  "project_code": null,
+  "phase_naming": "sequential",
+  "agent_skills": {},
+  "features": {},
+  "resolve_model_ids": "omit",
+  "mode": "yolo",
+  "granularity": "coarse"
+}

--- a/.planning/phases/01-cartridge-and-bus-foundation/01-01-PLAN.md
+++ b/.planning/phases/01-cartridge-and-bus-foundation/01-01-PLAN.md
@@ -1,0 +1,148 @@
+---
+phase: 01-cartridge-and-bus-foundation
+plan: "01"
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - src/lib.rs
+  - src/cartridge.rs
+  - src/main.rs
+autonomous: true
+requirements:
+  - CART-01
+  - CART-02
+user_setup: []
+must_haves:
+  truths:
+    - "D-01: The project has a reusable core entry at src/lib.rs and a focused src/cartridge.rs module."
+    - "D-02: src/main.rs stays a thin CLI boundary and delegates ROM loading to the core."
+    - "D-03: No new dependencies are added; implementation uses std and custom Result/error types with Display."
+    - "D-04: ROM loading uses std::fs::read or an equivalent byte-oriented API, not fs::read_to_string."
+    - "D-05: Missing, unreadable, too-short, and invalid ROM inputs produce clear errors instead of panics."
+    - "D-16: Unit tests use in-memory byte fixtures for validation."
+  artifacts:
+    - src/lib.rs
+    - src/cartridge.rs
+    - src/main.rs
+  key_links:
+    - "src/main.rs calls a public cartridge loading API exported through src/lib.rs."
+    - "Cartridge file loading returns Result and preserves IO errors for Display."
+---
+
+<objective>
+Replace the text-ROM prototype with binary cartridge loading and a reusable core boundary.
+
+Purpose: Real Game Boy ROMs are arbitrary bytes, so Phase 1 must stop treating user input as UTF-8 text before any emulator work can be trusted.
+Output: `src/lib.rs`, an initial `src/cartridge.rs` loading/error foundation, a refactored `src/main.rs`, and focused loading tests.
+</objective>
+
+<execution_context>
+@$HOME/.codex/get-shit-done/workflows/execute-plan.md
+@$HOME/.codex/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/REQUIREMENTS.md
+@.planning/phases/01-cartridge-and-bus-foundation/01-CONTEXT.md
+@.planning/phases/01-cartridge-and-bus-foundation/01-RESEARCH.md
+@.planning/phases/01-cartridge-and-bus-foundation/01-PATTERNS.md
+@src/main.rs
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Add the core module boundary and cartridge loading error type</name>
+  <files>src/lib.rs, src/cartridge.rs</files>
+  <read_first>.planning/phases/01-cartridge-and-bus-foundation/01-CONTEXT.md, .planning/phases/01-cartridge-and-bus-foundation/01-RESEARCH.md, src/main.rs</read_first>
+  <action>Create `src/lib.rs` with `pub mod cartridge;`. Create `src/cartridge.rs` with a dependency-free loading foundation: constants for `MIN_CARTRIDGE_HEADER_LEN` set to `0x150`, a `CartridgeError` enum covering IO, too-short ROM data, unsupported cartridge type, unsupported ROM size code, and unsupported RAM size code, and a `Display` implementation. Add a byte-oriented `load_rom_file(path: impl AsRef<std::path::Path>) -> Result<Vec<u8>, CartridgeError>` that uses `std::fs::read`, checks `len() >= 0x150`, and returns `TooShort { len }` for short inputs. Do not parse the full header in this task; leave that to Plan 01-02.</action>
+  <verify>cargo test</verify>
+  <acceptance_criteria>
+    - `src/lib.rs` contains `pub mod cartridge;`.
+    - `src/cartridge.rs` contains `MIN_CARTRIDGE_HEADER_LEN: usize = 0x150`.
+    - `src/cartridge.rs` contains `std::fs::read`.
+    - `src/cartridge.rs` implements `std::fmt::Display` for the custom error type.
+    - No code in `src/cartridge.rs` calls `read_to_string`.
+  </acceptance_criteria>
+  <done>The crate exposes a cartridge module and byte-loading API with clear loading errors.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Refactor the CLI to delegate binary ROM loading</name>
+  <files>src/main.rs</files>
+  <read_first>src/main.rs, src/lib.rs, src/cartridge.rs, .planning/codebase/ARCHITECTURE.md</read_first>
+  <action>Replace the direct `std::fs` use in `src/main.rs` with a call to the core loading API. Keep CLI responsibilities limited to argument handling, suffix validation for `.gb` and `.gbc`, invoking `game_girl::cartridge::load_rom_file`, and printing either `Loaded ROM: {n} bytes` or a concise error to stderr. Return a non-zero process exit code for ordinary user failures by using `std::process::ExitCode` or an equivalent explicit exit path. Remove `expect` so unreadable files and too-short files are not reported as panics.</action>
+  <verify>cargo run -- missing.gb; test $? -ne 0</verify>
+  <acceptance_criteria>
+    - `src/main.rs` does not contain `std::fs`.
+    - `src/main.rs` does not contain `read_to_string`.
+    - `src/main.rs` does not contain `.expect(` for ROM loading.
+    - `src/main.rs` imports or references `game_girl::cartridge::load_rom_file`.
+    - Missing, unreadable, too-short, or invalid file inputs print human-facing error text.
+  </acceptance_criteria>
+  <done>The CLI delegates to the core and handles normal loading failures without panicking.</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Add focused binary loading tests</name>
+  <files>src/cartridge.rs</files>
+  <read_first>src/cartridge.rs, .planning/codebase/TESTING.md, .planning/phases/01-cartridge-and-bus-foundation/01-RESEARCH.md</read_first>
+  <action>Add unit tests in `src/cartridge.rs` using in-memory byte fixtures and temporary files only when file IO is directly under test. Cover the minimum header-length guard and `Display` text for too-short ROM data. If a temporary file is needed, use only `std` APIs and avoid adding test dependencies. Keep the fixture helper small, for example a `rom_bytes()` helper that returns a `Vec<u8>` of at least `0x150` bytes.</action>
+  <verify>cargo test cartridge</verify>
+  <acceptance_criteria>
+    - `src/cartridge.rs` contains a `#[cfg(test)]` module.
+    - Tests assert that short byte buffers fail with a too-short error.
+    - Tests assert that valid-length byte buffers pass the initial loading validation.
+    - Tests do not depend on blargg, mooneye, or broad ROM execution.
+  </acceptance_criteria>
+  <done>Binary loading behavior is covered by fast Cargo tests.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+Assets:
+- User-supplied ROM file bytes.
+- CLI error reporting path.
+- Future core APIs that will trust cartridge byte validation.
+
+Threats:
+- Text decoding corrupts or rejects valid binary ROM data.
+- Expected filesystem or validation failures panic through `expect`.
+- Too-short ROMs cause unchecked header indexing in later work.
+
+Mitigations:
+- Use `std::fs::read`.
+- Gate initial ROM loading on `len() >= 0x150`.
+- Return a custom `CartridgeError` with `Display`.
+- Keep CLI handling explicit and non-panicking.
+
+Residual risk:
+- Full header semantic validation lands in Plan 01-02.
+- Nintendo logo and checksum validation are not hard gates in this plan.
+</threat_model>
+
+<verification>
+Before declaring plan complete:
+- [ ] `cargo fmt --all`
+- [ ] `cargo test`
+- [ ] `cargo run -- missing.gb` prints a clear error and exits non-zero
+- [ ] `rg "read_to_string|expect\\(" src` does not show ROM-loading usage
+</verification>
+
+<success_criteria>
+
+- `CART-01` is satisfied for byte-oriented ROM reads.
+- `CART-02` is partially satisfied for missing, unreadable, too-short, and invalid path handling.
+- The crate has a reusable core module boundary.
+- The CLI owns user interaction only.
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/01-cartridge-and-bus-foundation/01-01-SUMMARY.md`.
+</output>
+

--- a/.planning/phases/01-cartridge-and-bus-foundation/01-01-SUMMARY.md
+++ b/.planning/phases/01-cartridge-and-bus-foundation/01-01-SUMMARY.md
@@ -1,0 +1,107 @@
+---
+phase: 01-cartridge-and-bus-foundation
+plan: "01"
+subsystem: cartridge
+tags: [rust, cartridge, cli, binary-loading]
+requires: []
+provides:
+  - Reusable Rust library module boundary
+  - Byte-oriented ROM file loading
+  - Cartridge loading error type with Display output
+  - CLI delegation to the cartridge loader
+affects: [phase-01, phase-02, cartridge, cli]
+tech-stack:
+  added: []
+  patterns:
+    - Dependency-free Rust core modules
+    - Thin CLI boundary delegating to library APIs
+key-files:
+  created:
+    - src/lib.rs
+    - src/cartridge.rs
+  modified:
+    - src/main.rs
+    - src/cartridge.rs
+key-decisions:
+  - "Introduced src/lib.rs as the reusable emulator core entry point."
+  - "Kept src/main.rs focused on argument handling, extension checks, user-facing output, and exit codes."
+  - "Validated ROM bytes with a 0x150 minimum length before future header parsing."
+patterns-established:
+  - "Core loading APIs return Result values and leave presentation to the CLI boundary."
+  - "Cartridge tests use in-memory byte fixtures rather than checked-in ROM execution."
+requirements-completed: [CART-01, CART-02]
+duration: 3 min
+completed: 2026-05-02
+---
+
+# Phase 01 Plan 01: Binary Cartridge Loading Summary
+
+**Dependency-free binary ROM loading with a reusable cartridge module and non-panicking CLI error reporting**
+
+## Performance
+
+- **Duration:** 3 min
+- **Started:** 2026-05-02T02:53:35Z
+- **Completed:** 2026-05-02T02:56:06Z
+- **Tasks:** 3
+- **Files modified:** 3
+
+## Accomplishments
+
+- Added `src/lib.rs` and exported `pub mod cartridge;` as the first reusable core boundary.
+- Added `src/cartridge.rs` with byte-oriented ROM loading through `std::fs::read`, minimum header length validation, and a custom `CartridgeError` with `Display`.
+- Refactored `src/main.rs` so the CLI delegates to `game_girl::cartridge::load_rom_file`, reports clear errors, and exits non-zero for normal user failures.
+- Added fast in-memory unit tests for too-short ROM rejection, valid header-length acceptance, and human-readable error display.
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Add the core module boundary and cartridge loading error type** - `a557de5` (feat)
+2. **Task 2: Refactor the CLI to delegate binary ROM loading** - `990134a` (feat)
+3. **Task 3: Add focused binary loading tests** - `828b1d6` (test)
+
+## Files Created/Modified
+
+- `src/lib.rs` - Exposes the cartridge module for the reusable emulator core.
+- `src/cartridge.rs` - Defines the ROM loading guard, cartridge loading errors, and unit tests.
+- `src/main.rs` - Delegates ROM loading to the library and reports user errors without panics.
+
+## Decisions Made
+
+- Kept file loading as `Vec<u8>` for this plan so full header parsing can land cleanly in Plan 01-02.
+- Used `std::process::ExitCode` in the CLI so missing paths, invalid suffixes, unreadable files, and too-short ROMs are observable failures.
+- Kept tests in `src/cartridge.rs` and avoided checked-in ROM suite execution.
+
+## Deviations from Plan
+
+None - plan executed exactly as written.
+
+---
+
+**Total deviations:** 0 auto-fixed.
+**Impact on plan:** No scope changes.
+
+## Issues Encountered
+
+None.
+
+## User Setup Required
+
+None - no external service configuration required.
+
+## Verification
+
+- `cargo fmt --all` passed.
+- `cargo test` passed.
+- `cargo test cartridge` passed.
+- `cargo run -- missing.gb` printed a clear error and exited non-zero.
+- `rg "read_to_string|expect\\(" src` found no matches.
+
+## Next Phase Readiness
+
+Plan 01-02 can build directly on `src/cartridge.rs` by replacing raw byte validation with a parsed `Cartridge` and `CartridgeHeader` while keeping the CLI boundary stable.
+
+---
+*Phase: 01-cartridge-and-bus-foundation*
+*Completed: 2026-05-02*

--- a/.planning/phases/01-cartridge-and-bus-foundation/01-02-PLAN.md
+++ b/.planning/phases/01-cartridge-and-bus-foundation/01-02-PLAN.md
@@ -12,6 +12,7 @@ requirements:
   - CART-02
   - CART-03
   - CART-04
+  - CART-05
 user_setup: []
 must_haves:
   truths:
@@ -140,10 +141,10 @@ Before declaring plan complete:
 - `CART-02` is satisfied for invalid header metadata.
 - `CART-03` is satisfied by exposed parsed header fields.
 - `CART-04` is satisfied by readable ROM-only cartridges.
+- `CART-05` is satisfied by parsing unsupported cartridge types far enough to report `UnsupportedCartridgeType`.
 - Plan 01-03 can construct a Bus around the cartridge API.
 </success_criteria>
 
 <output>
 After completion, create `.planning/phases/01-cartridge-and-bus-foundation/01-02-SUMMARY.md`.
 </output>
-

--- a/.planning/phases/01-cartridge-and-bus-foundation/01-02-PLAN.md
+++ b/.planning/phases/01-cartridge-and-bus-foundation/01-02-PLAN.md
@@ -1,0 +1,149 @@
+---
+phase: 01-cartridge-and-bus-foundation
+plan: "02"
+type: execute
+wave: 2
+depends_on:
+  - "01-01"
+files_modified:
+  - src/cartridge.rs
+autonomous: true
+requirements:
+  - CART-02
+  - CART-03
+  - CART-04
+user_setup: []
+must_haves:
+  truths:
+    - "D-03: Header parsing remains dependency-free and uses std plus custom Result/error types with Display."
+    - "D-05: Unsupported/unknown cartridge types and invalid size codes fail clearly."
+    - "D-06: Cartridge parsing exposes title, cartridge type, ROM size, RAM size, entry bytes, and header-region metadata."
+    - "D-07: Cartridge type 0x00 creates a readable ROM-only cartridge; other MBC types return unsupported errors."
+    - "D-08: Nintendo logo and checksum data are metadata only and are not hard gates in Phase 1."
+    - "D-09: CGB header data is metadata only and does not imply CGB execution support."
+    - "D-15: Tests cover parsing, invalid input errors, unsupported cartridge types, and ROM-only reads."
+    - "D-16: Tests prefer in-memory ROM byte fixtures."
+  artifacts:
+    - src/cartridge.rs
+  key_links:
+    - "Cartridge::from_bytes validates bytes before any header indexing."
+    - "ROM-only read behavior is exposed for Bus integration in Plan 01-03."
+---
+
+<objective>
+Parse cartridge headers and model ROM-only cartridge reads.
+
+Purpose: CPU and Bus work need a trustworthy cartridge representation with metadata and ROM reads, not just a raw byte buffer.
+Output: Cartridge/header structs, ROM/RAM size decoding, unsupported-type validation, ROM-only reads, and cartridge parser tests.
+</objective>
+
+<execution_context>
+@$HOME/.codex/get-shit-done/workflows/execute-plan.md
+@$HOME/.codex/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/REQUIREMENTS.md
+@.planning/phases/01-cartridge-and-bus-foundation/01-CONTEXT.md
+@.planning/phases/01-cartridge-and-bus-foundation/01-RESEARCH.md
+@.planning/phases/01-cartridge-and-bus-foundation/01-PATTERNS.md
+@.planning/phases/01-cartridge-and-bus-foundation/01-01-SUMMARY.md
+@src/cartridge.rs
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Define cartridge metadata and parser types</name>
+  <files>src/cartridge.rs</files>
+  <read_first>src/cartridge.rs, .planning/phases/01-cartridge-and-bus-foundation/01-RESEARCH.md, .planning/phases/01-cartridge-and-bus-foundation/01-CONTEXT.md</read_first>
+  <action>Extend `src/cartridge.rs` with a `Cartridge` struct that owns ROM bytes and a parsed `CartridgeHeader`. Add a `CartridgeHeader` struct exposing title, cartridge type, ROM size bytes, RAM size bytes, entry point bytes, logo bytes or header bytes, CGB flag metadata, header checksum, and global checksum metadata. Use named constants for offsets: entry `0x0100..0x0104`, title `0x0134..0x0144`, CGB flag `0x0143`, cartridge type `0x0147`, ROM size `0x0148`, RAM size `0x0149`, header checksum `0x014D`, and global checksum `0x014E..0x0150`. Trim title trailing `0x00` bytes without assuming the whole ROM is text.</action>
+  <verify>cargo test cartridge</verify>
+  <acceptance_criteria>
+    - `src/cartridge.rs` contains `pub struct Cartridge`.
+    - `src/cartridge.rs` contains `pub struct CartridgeHeader`.
+    - `CartridgeHeader` exposes title, cartridge type, ROM size, RAM size, entry, and checksum/header metadata.
+    - Header parsing checks the ROM length before slicing header offsets.
+  </acceptance_criteria>
+  <done>Header metadata is represented by explicit cartridge types.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Validate ROM-only type and size codes</name>
+  <files>src/cartridge.rs</files>
+  <read_first>src/cartridge.rs, .planning/phases/01-cartridge-and-bus-foundation/01-RESEARCH.md</read_first>
+  <action>Implement `Cartridge::from_bytes(bytes: Vec<u8>) -> Result<Self, CartridgeError>`. Accept cartridge type `0x00` as ROM-only and return `UnsupportedCartridgeType(code)` for every other type in Phase 1. Decode ROM size codes `0x00..=0x08` to byte counts and RAM size codes `0x00..=0x05` using the mapping in `01-RESEARCH.md`; return explicit unsupported-size errors for unknown codes. Do not reject on Nintendo logo or checksum mismatch; store those values as metadata only. Keep CGB flag as metadata only.</action>
+  <verify>cargo test cartridge</verify>
+  <acceptance_criteria>
+    - `Cartridge::from_bytes` accepts a valid-length ROM with type `0x00`.
+    - Non-`0x00` cartridge types return `UnsupportedCartridgeType`.
+    - Unsupported ROM size and RAM size codes return explicit errors.
+    - Code does not enforce Nintendo logo or checksum validity as a hard gate.
+  </acceptance_criteria>
+  <done>ROM-only cartridges construct successfully and unsupported cartridge metadata fails explicitly.</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Add ROM-only read behavior and parser tests</name>
+  <files>src/cartridge.rs</files>
+  <read_first>src/cartridge.rs, .planning/codebase/TESTING.md, .planning/phases/01-cartridge-and-bus-foundation/01-RESEARCH.md</read_first>
+  <action>Add a ROM-only read API such as `Cartridge::read_rom(&self, address: u16) -> u8` for `0x0000..=0x7FFF`. For now, reads beyond available bytes in the valid ROM address range should return a deterministic open-bus-style value such as `0xFF` rather than panicking. Add a cartridge write policy hook such as `write_rom(&mut self, address: u16, value: u8)` that is a no-op for ROM-only cartridges so Plan 01-03 can route ROM-range writes to the cartridge layer. Add tests with in-memory ROM bytes for title parsing, entry bytes, ROM/RAM size decoding, unsupported type, unsupported size code, too-short ROM, ROM reads, and no panic on ROM-range read beyond the fixture size.</action>
+  <verify>cargo test cartridge</verify>
+  <acceptance_criteria>
+    - Tests cover parsed title, cartridge type, ROM size, RAM size, and entry bytes.
+    - Tests cover unsupported cartridge type and unsupported ROM/RAM size codes.
+    - Tests cover ROM-only reads from `0x0000` and `0x7FFF`.
+    - Tests cover that ROM-only writes do not mutate ROM bytes or panic.
+  </acceptance_criteria>
+  <done>Cartridge behavior is ready for Bus integration.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+Assets:
+- Cartridge byte buffer.
+- Header metadata used by downstream CPU, Bus, and later mapper work.
+- Error messages surfaced to CLI users.
+
+Threats:
+- Header parsing indexes into short buffers.
+- Unknown cartridge metadata is silently accepted and later mis-executed.
+- Title parsing treats binary ROM data as unrestricted UTF-8 text.
+- Checksum or CGB metadata creates false compatibility claims.
+
+Mitigations:
+- Check minimum length before all header slicing.
+- Accept only ROM-only cartridge type `0x00` in Phase 1.
+- Reject unknown ROM/RAM size codes with explicit errors.
+- Convert title bytes lossily or conservatively after trimming null bytes, without decoding the whole ROM.
+- Store checksum and CGB values as metadata only.
+
+Residual risk:
+- Full MBC behavior is deferred.
+- Logo/checksum validation is intentionally not a hard gate.
+</threat_model>
+
+<verification>
+Before declaring plan complete:
+- [ ] `cargo fmt --all`
+- [ ] `cargo test`
+- [ ] `cargo test cartridge`
+- [ ] `rg "UnsupportedCartridgeType|UnsupportedRomSize|UnsupportedRamSize" src/cartridge.rs`
+</verification>
+
+<success_criteria>
+
+- `CART-02` is satisfied for invalid header metadata.
+- `CART-03` is satisfied by exposed parsed header fields.
+- `CART-04` is satisfied by readable ROM-only cartridges.
+- Plan 01-03 can construct a Bus around the cartridge API.
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/01-cartridge-and-bus-foundation/01-02-SUMMARY.md`.
+</output>
+

--- a/.planning/phases/01-cartridge-and-bus-foundation/01-02-SUMMARY.md
+++ b/.planning/phases/01-cartridge-and-bus-foundation/01-02-SUMMARY.md
@@ -1,0 +1,106 @@
+---
+phase: 01-cartridge-and-bus-foundation
+plan: "02"
+subsystem: cartridge
+tags: [rust, cartridge-header, rom-only, validation]
+requires:
+  - phase: 01-01
+    provides: Binary ROM loading and cartridge error foundation
+provides:
+  - Parsed cartridge header metadata
+  - ROM-only cartridge construction
+  - Unsupported cartridge and size-code errors
+  - ROM-only read and write policy hooks
+affects: [phase-01, phase-02, phase-03, cartridge, bus]
+tech-stack:
+  added: []
+  patterns:
+    - Explicit header offset constants
+    - Bounds-checked parsing before header slicing
+    - In-memory cartridge fixtures for unit tests
+key-files:
+  created: []
+  modified:
+    - src/cartridge.rs
+key-decisions:
+  - "CartridgeHeader stores logo, checksum, CGB flag, and raw header bytes as metadata only."
+  - "Cartridge::from_bytes accepts only ROM-only cartridge type 0x00 in Phase 1."
+  - "ROM-only writes are routed to a cartridge policy hook and intentionally do not mutate ROM bytes."
+patterns-established:
+  - "Cartridge constructors validate size/type metadata before exposing a usable cartridge."
+  - "ROM reads return 0xFF for missing fixture bytes instead of panicking."
+requirements-completed: [CART-02, CART-03, CART-04, CART-05]
+duration: 4 min
+completed: 2026-05-02
+---
+
+# Phase 01 Plan 02: Cartridge Header and ROM-Only Summary
+
+**Parsed Game Boy cartridge headers with ROM-only construction, explicit unsupported-type errors, and fixed ROM read hooks**
+
+## Performance
+
+- **Duration:** 4 min
+- **Started:** 2026-05-02T02:57:15Z
+- **Completed:** 2026-05-02T03:01:15Z
+- **Tasks:** 3
+- **Files modified:** 1
+
+## Accomplishments
+
+- Added `Cartridge`, `CartridgeHeader`, and `CartridgeType` with explicit constants for Game Boy header offsets.
+- Parsed title, cartridge type, ROM/RAM size codes, entry point, logo bytes, CGB flag, header checksum, global checksum, and raw header bytes.
+- Added `Cartridge::from_bytes` and `load_cartridge_file`, accepting ROM-only cartridges and rejecting unsupported MBC/size codes with clear errors.
+- Added ROM-only `read_rom` and `write_rom` hooks for Bus integration.
+- Expanded cartridge tests from 3 to 11 focused unit tests.
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Define cartridge metadata and parser types** - `2810e8d` (feat)
+2. **Task 2: Validate ROM-only type and size codes** - `cf7a27e` (feat)
+3. **Task 3: Add ROM-only read behavior and parser tests** - `48a4549` (feat)
+
+## Files Created/Modified
+
+- `src/cartridge.rs` - Adds the parsed cartridge model, semantic validation, ROM-only reads/writes, and parser tests.
+
+## Decisions Made
+
+- Kept Nintendo logo and checksum values as exposed metadata, not hard validation gates.
+- Kept CGB flag data as metadata only.
+- Left broad MBC support deferred while still reporting unsupported type codes clearly.
+
+## Deviations from Plan
+
+None - plan executed exactly as written.
+
+---
+
+**Total deviations:** 0 auto-fixed.
+**Impact on plan:** No scope changes.
+
+## Issues Encountered
+
+None.
+
+## User Setup Required
+
+None - no external service configuration required.
+
+## Verification
+
+- `cargo fmt --all` passed.
+- `cargo test` passed.
+- `cargo test cartridge` passed with 11 cartridge tests.
+- Grep for `UnsupportedCartridgeType`, `UnsupportedRomSize`, and `UnsupportedRamSize` found the expected validation paths in `src/cartridge.rs`.
+- Cargo run against the hello-world ROM fixture loaded the ROM and printed `Loaded ROM: 32768 bytes`.
+
+## Next Phase Readiness
+
+Plan 01-03 can now construct a `Bus` around a ROM-only `Cartridge` and delegate ROM-range reads and writes to cartridge policy instead of duplicating cartridge behavior.
+
+---
+*Phase: 01-cartridge-and-bus-foundation*
+*Completed: 2026-05-02*

--- a/.planning/phases/01-cartridge-and-bus-foundation/01-03-PLAN.md
+++ b/.planning/phases/01-cartridge-and-bus-foundation/01-03-PLAN.md
@@ -1,0 +1,157 @@
+---
+phase: 01-cartridge-and-bus-foundation
+plan: "03"
+type: execute
+wave: 3
+depends_on:
+  - "01-02"
+files_modified:
+  - src/lib.rs
+  - src/bus.rs
+  - src/cartridge.rs
+autonomous: true
+requirements:
+  - CART-04
+  - BUS-01
+  - BUS-02
+  - BUS-03
+  - BUS-04
+user_setup: []
+must_haves:
+  truths:
+    - "D-01: The reusable core includes a focused src/bus.rs module exported from src/lib.rs."
+    - "D-10: Bus exposes read8(addr: u16) and write8(addr: u16, value: u8)."
+    - "D-11: CPU-visible memory has a Bus path from the start; future CPU code should not bypass it."
+    - "D-12: Bus covers cartridge ROM, WRAM, Echo RAM, OAM placeholder, unusable range, I/O, HRAM, and IE."
+    - "D-13: Writes to ROM address ranges route to the cartridge layer, with ROM-only policy handled there."
+    - "D-14: read16/write16, CPU fetch helpers, timer side effects, PPU restrictions, and interrupt semantics remain deferred."
+    - "D-15: Tests cover ROM reads, WRAM, Echo RAM, unusable range, HRAM, I/O, IE, and representative writes."
+    - "D-17: blargg/mooneye execution, serial pass/fail detection, and deterministic ROM timeouts remain deferred to Phase 4."
+  artifacts:
+    - src/lib.rs
+    - src/bus.rs
+    - src/cartridge.rs
+  key_links:
+    - "Bus owns or receives a Cartridge and delegates ROM-range reads/writes to it."
+    - "Bus tests construct in-memory ROM-only cartridges from the cartridge API."
+---
+
+<objective>
+Introduce Bus address routing with focused tests.
+
+Purpose: The emulator needs one CPU-visible memory boundary before CPU work begins, so later instruction execution goes through hardware-shaped address routing instead of direct module access.
+Output: `src/bus.rs`, `pub mod bus;`, Bus read/write APIs, simple backing storage for Phase 1 ranges, and address-routing tests.
+</objective>
+
+<execution_context>
+@$HOME/.codex/get-shit-done/workflows/execute-plan.md
+@$HOME/.codex/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/REQUIREMENTS.md
+@.planning/phases/01-cartridge-and-bus-foundation/01-CONTEXT.md
+@.planning/phases/01-cartridge-and-bus-foundation/01-RESEARCH.md
+@.planning/phases/01-cartridge-and-bus-foundation/01-PATTERNS.md
+@.planning/phases/01-cartridge-and-bus-foundation/01-02-SUMMARY.md
+@src/lib.rs
+@src/cartridge.rs
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Add Bus struct and module export</name>
+  <files>src/lib.rs, src/bus.rs</files>
+  <read_first>src/lib.rs, src/cartridge.rs, .planning/phases/01-cartridge-and-bus-foundation/01-RESEARCH.md, docs/gameboy_architecture_summary.md</read_first>
+  <action>Create `src/bus.rs` and export it from `src/lib.rs` with `pub mod bus;`. Implement `pub struct Bus` that owns a `Cartridge` and fixed-size storage for WRAM `[u8; 0x2000]`, OAM `[u8; 0xA0]`, I/O `[u8; 0x80]`, HRAM `[u8; 0x7F]`, and IE `u8`. Add `Bus::new(cartridge: Cartridge) -> Self`, `read8(&self, addr: u16) -> u8`, and `write8(&mut self, addr: u16, value: u8)`. Keep the API byte-oriented; do not add read16/write16 or CPU fetch helpers.</action>
+  <verify>cargo test bus</verify>
+  <acceptance_criteria>
+    - `src/lib.rs` contains `pub mod bus;`.
+    - `src/bus.rs` contains `pub struct Bus`.
+    - `src/bus.rs` contains `read8(&self, addr: u16) -> u8`.
+    - `src/bus.rs` contains `write8(&mut self, addr: u16, value: u8)`.
+    - `src/bus.rs` does not introduce CPU, timer, interrupt service, or PPU mode behavior.
+  </acceptance_criteria>
+  <done>The core exposes a Bus type ready for address routing.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Route Phase 1 memory ranges</name>
+  <files>src/bus.rs, src/cartridge.rs</files>
+  <read_first>src/bus.rs, src/cartridge.rs, .planning/phases/01-cartridge-and-bus-foundation/01-CONTEXT.md, .planning/phases/01-cartridge-and-bus-foundation/01-RESEARCH.md</read_first>
+  <action>Implement Bus range routing exactly for Phase 1. Reads from `0x0000..=0x7FFF` call `cartridge.read_rom(addr)`. Writes to `0x0000..=0x7FFF` call the cartridge ROM write policy hook from Plan 01-02. Reads and writes to `0xC000..=0xDFFF` access WRAM. Reads and writes to `0xE000..=0xFDFF` mirror WRAM using address minus `0xE000` modulo `0x2000`. Reads and writes to `0xFE00..=0xFE9F` access OAM placeholder storage. Reads from `0xFEA0..=0xFEFF` return `0xFF` and writes are ignored. Reads and writes to `0xFF00..=0xFF7F` access I/O storage. Reads and writes to `0xFF80..=0xFFFE` access HRAM. Reads and writes to `0xFFFF` access IE. For ranges outside this Phase 1 set, return `0xFF` on reads and ignore writes unless implementing a tiny prepared placeholder is clearly simpler.</action>
+  <verify>cargo test bus</verify>
+  <acceptance_criteria>
+    - Cartridge ROM reads are delegated to the cartridge.
+    - Cartridge ROM writes call the cartridge layer.
+    - WRAM and Echo RAM mirror each other.
+    - Unusable range reads return `0xFF` and writes do not persist.
+    - I/O, HRAM, and IE writes can be read back.
+  </acceptance_criteria>
+  <done>Bus routing covers every Phase 1 success-criteria range.</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Add representative Bus routing tests</name>
+  <files>src/bus.rs</files>
+  <read_first>src/bus.rs, src/cartridge.rs, .planning/codebase/TESTING.md, .planning/phases/01-cartridge-and-bus-foundation/01-RESEARCH.md</read_first>
+  <action>Add unit tests in `src/bus.rs` using an in-memory ROM-only cartridge fixture. Cover cartridge ROM reads at representative addresses, WRAM read/write, Echo RAM mirror read/write in both directions, OAM placeholder read/write, unusable range read/write behavior, I/O storage, HRAM storage, IE storage, and ROM-range write routing behavior. Keep tests deterministic and avoid blargg/mooneye execution.</action>
+  <verify>cargo test bus</verify>
+  <acceptance_criteria>
+    - `src/bus.rs` contains tests for `0x0000`, `0x7FFF`, `0xC000`, `0xE000`, `0xFE00`, `0xFEA0`, `0xFF00`, `0xFF80`, and `0xFFFF`.
+    - `cargo test bus` passes.
+    - Bus tests do not execute checked-in ROM suites.
+  </acceptance_criteria>
+  <done>Bus routing has focused coverage for required memory ranges.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+Assets:
+- CPU-visible address space behavior.
+- Cartridge ROM bytes and ROM write policy.
+- Future CPU integration boundary.
+
+Threats:
+- CPU work later bypasses Bus because the Bus API is incomplete or unclear.
+- ROM address writes are swallowed by Bus instead of delegated to cartridge policy.
+- Echo RAM or unusable range behavior is implemented inconsistently and hidden by weak tests.
+- Out-of-scope timer, interrupt, or PPU side effects slip into the Bus too early.
+
+Mitigations:
+- Expose `read8` and `write8` as the canonical Phase 1 Bus API.
+- Delegate cartridge ROM reads and writes to `Cartridge`.
+- Test every required address class with exact representative addresses.
+- Keep read16/write16, CPU fetch helpers, timer side effects, PPU restrictions, interrupt semantics, and ROM test harnessing out of this plan.
+
+Residual risk:
+- VRAM, external RAM, timer registers, PPU restrictions, and interrupt semantics are placeholders until later phases.
+- Bus timing and cycle effects are not modeled until CPU/timer/PPU phases.
+</threat_model>
+
+<verification>
+Before declaring plan complete:
+- [ ] `cargo fmt --all`
+- [ ] `cargo test`
+- [ ] `cargo test bus`
+- [ ] `rg "read16|write16|fetch" src/bus.rs` confirms out-of-scope helpers were not introduced unless explicitly justified in the summary
+</verification>
+
+<success_criteria>
+
+- `CART-04` remains satisfied through Bus-level ROM reads.
+- `BUS-01` is satisfied by `read8` and `write8` across the 16-bit address space.
+- `BUS-02` is satisfied by routed reads for cartridge ROM, WRAM, HRAM, IE, and I/O.
+- `BUS-03` is satisfied by routed writes for writable memory and I/O, plus cartridge-layer ROM write routing.
+- `BUS-04` is satisfied by representative tests for valid and unusable ranges.
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/01-cartridge-and-bus-foundation/01-03-SUMMARY.md`.
+</output>
+

--- a/.planning/phases/01-cartridge-and-bus-foundation/01-03-PLAN.md
+++ b/.planning/phases/01-cartridge-and-bus-foundation/01-03-PLAN.md
@@ -26,7 +26,7 @@ must_haves:
     - "D-13: Writes to ROM address ranges route to the cartridge layer, with ROM-only policy handled there."
     - "D-14: read16/write16, CPU fetch helpers, timer side effects, PPU restrictions, and interrupt semantics remain deferred."
     - "D-15: Tests cover ROM reads, WRAM, Echo RAM, unusable range, HRAM, I/O, IE, and representative writes."
-    - "D-17: blargg/mooneye execution, serial pass/fail detection, and deterministic ROM timeouts remain deferred to Phase 4."
+    - "D-17: Serial pass/fail capture and deterministic ROM timeouts remain deferred to inserted Phase 2.1; broader blargg/mooneye expansion remains deferred to Phase 4."
   artifacts:
     - src/lib.rs
     - src/bus.rs
@@ -99,7 +99,7 @@ Output: `src/bus.rs`, `pub mod bus;`, Bus read/write APIs, simple backing storag
   <name>Task 3: Add representative Bus routing tests</name>
   <files>src/bus.rs</files>
   <read_first>src/bus.rs, src/cartridge.rs, .planning/codebase/TESTING.md, .planning/phases/01-cartridge-and-bus-foundation/01-RESEARCH.md</read_first>
-  <action>Add unit tests in `src/bus.rs` using an in-memory ROM-only cartridge fixture. Cover cartridge ROM reads at representative addresses, WRAM read/write, Echo RAM mirror read/write in both directions, OAM placeholder read/write, unusable range read/write behavior, I/O storage, HRAM storage, IE storage, and ROM-range write routing behavior. Keep tests deterministic and avoid blargg/mooneye execution.</action>
+  <action>Add unit tests in `src/bus.rs` using an in-memory ROM-only cartridge fixture. Cover cartridge ROM reads at representative addresses, WRAM read/write, Echo RAM mirror read/write in both directions, OAM placeholder read/write, unusable range read/write behavior, I/O storage, HRAM storage, IE storage, and ROM-range write routing behavior. Keep tests deterministic and avoid ROM fixture execution until Phase 2.1.</action>
   <verify>cargo test bus</verify>
   <acceptance_criteria>
     - `src/bus.rs` contains tests for `0x0000`, `0x7FFF`, `0xC000`, `0xE000`, `0xFE00`, `0xFEA0`, `0xFF00`, `0xFF80`, and `0xFFFF`.
@@ -154,4 +154,3 @@ Before declaring plan complete:
 <output>
 After completion, create `.planning/phases/01-cartridge-and-bus-foundation/01-03-SUMMARY.md`.
 </output>
-

--- a/.planning/phases/01-cartridge-and-bus-foundation/01-03-SUMMARY.md
+++ b/.planning/phases/01-cartridge-and-bus-foundation/01-03-SUMMARY.md
@@ -1,0 +1,108 @@
+---
+phase: 01-cartridge-and-bus-foundation
+plan: "03"
+subsystem: bus
+tags: [rust, bus, memory-map, dmg]
+requires:
+  - phase: 01-02
+    provides: ROM-only cartridge construction and read/write policy hooks
+provides:
+  - Bus module exported from the reusable core
+  - 8-bit read/write API over the 16-bit address space
+  - Phase 1 routing for cartridge ROM, WRAM, Echo RAM, OAM, I/O, HRAM, and IE
+  - Representative Bus unit tests
+affects: [phase-01, phase-02, phase-03, bus, cpu]
+tech-stack:
+  added: []
+  patterns:
+    - Fixed-size arrays for simple memory regions
+    - Bus delegates cartridge policy to Cartridge
+    - In-memory ROM-only fixture for Bus tests
+key-files:
+  created:
+    - src/bus.rs
+  modified:
+    - src/lib.rs
+    - src/bus.rs
+key-decisions:
+  - "Bus owns the Cartridge and delegates ROM reads/writes to the cartridge layer."
+  - "Unusable memory range FEA0-FEFF reads as 0xFF and ignores writes."
+  - "read16/write16, CPU fetch helpers, timer side effects, PPU access restrictions, and interrupt semantics remain deferred."
+patterns-established:
+  - "Future CPU work should access memory through Bus::read8 and Bus::write8."
+  - "Phase 1 memory ranges are tested with exact representative addresses."
+requirements-completed: [CART-04, BUS-01, BUS-02, BUS-03, BUS-04]
+duration: 4 min
+completed: 2026-05-02
+---
+
+# Phase 01 Plan 03: Bus Address Routing Summary
+
+**DMG Bus skeleton with cartridge delegation, writable core memory ranges, unusable range behavior, and focused address tests**
+
+## Performance
+
+- **Duration:** 4 min
+- **Started:** 2026-05-02T03:01:15Z
+- **Completed:** 2026-05-02T03:05:23Z
+- **Tasks:** 3
+- **Files modified:** 2
+
+## Accomplishments
+
+- Added `src/bus.rs` and exported it through `src/lib.rs`.
+- Implemented `Bus::new`, `read8`, and `write8`.
+- Routed cartridge ROM, WRAM, Echo RAM, OAM placeholder storage, unusable range, I/O register storage, HRAM, and IE.
+- Added 6 Bus tests covering exact representative addresses and ROM write delegation behavior.
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Add Bus struct and module export** - `9367d89` (feat)
+2. **Task 2: Route Phase 1 memory ranges** - `d3c789f` (feat)
+3. **Task 3: Add representative Bus routing tests** - `54ec3f0` (test)
+
+## Files Created/Modified
+
+- `src/bus.rs` - Implements Bus ownership, address routing, and Bus unit tests.
+- `src/lib.rs` - Exports the Bus module from the reusable core.
+
+## Decisions Made
+
+- Backed OAM with simple placeholder storage so later PPU access rules can attach cleanly.
+- Returned `0xFF` for out-of-scope or unusable reads and ignored unsupported writes in Phase 1.
+- Kept Bus byte-only for now; no word helpers or CPU fetch helpers were added.
+
+## Deviations from Plan
+
+None - plan executed exactly as written.
+
+---
+
+**Total deviations:** 0 auto-fixed.
+**Impact on plan:** No scope changes.
+
+## Issues Encountered
+
+None.
+
+## User Setup Required
+
+None - no external service configuration required.
+
+## Verification
+
+- `cargo fmt --all` passed.
+- `cargo test` passed with 17 tests.
+- `cargo test bus` passed with 6 Bus tests.
+- Grep confirmed no `read16`, `write16`, or `fetch` helpers exist in `src/bus.rs`.
+- Cargo run against the hello-world ROM fixture loaded the ROM and printed `Loaded ROM: 32768 bytes`.
+
+## Next Phase Readiness
+
+Phase 2 can build CPU state and instruction fetch around `Bus::read8` and `Bus::write8`, with cartridge ROM and core memory ranges already routed through a central boundary.
+
+---
+*Phase: 01-cartridge-and-bus-foundation*
+*Completed: 2026-05-02*

--- a/.planning/phases/01-cartridge-and-bus-foundation/01-CONTEXT.md
+++ b/.planning/phases/01-cartridge-and-bus-foundation/01-CONTEXT.md
@@ -1,0 +1,118 @@
+# Phase 1: Cartridge and Bus Foundation - Context
+
+**Gathered:** 2026-05-02
+**Status:** Ready for planning
+
+<domain>
+## Phase Boundary
+
+Phase 1 replaces the current placeholder ROM text-loading CLI with binary cartridge loading, basic cartridge header parsing, ROM-only cartridge reads, and a tested DMG Bus skeleton for core memory ranges.
+
+This phase does **not** execute CPU instructions, run ROM test suites, implement timers/interrupts, render pixels, implement broad MBC support, add CGB behavior, or build a UI/audio host. Those are later phases.
+
+</domain>
+
+<decisions>
+## Implementation Decisions
+
+### Module Boundaries
+- **D-01:** Create a reusable emulator core now instead of continuing the single-file prototype. Add `src/lib.rs` and focused modules such as `src/cartridge.rs` and `src/bus.rs`.
+- **D-02:** Keep `src/main.rs` as a thin CLI boundary: parse the ROM path, call core loading APIs, print clear human-facing errors, and avoid embedding emulator hardware logic in the CLI.
+- **D-03:** Do not add new dependencies in Phase 1. Use Rust standard library APIs and custom `Result`/error types that implement `Display`.
+
+### Cartridge Loading and Validation
+- **D-04:** Replace `fs::read_to_string` with byte-oriented ROM loading via `std::fs::read`.
+- **D-05:** Treat ROM input as untrusted binary data. Hard-fail missing paths, unreadable files, files shorter than the cartridge header range, unsupported/unknown cartridge type for the Phase 1 implementation, and unsupported/invalid size codes.
+- **D-06:** Parse cartridge title, cartridge type, ROM size, RAM size, and relevant header/entry fields needed by downstream phases.
+- **D-07:** Support ROM-only cartridge behavior first. Cartridge type `0x00` should be constructible and readable through the ROM address ranges. Other MBC types should return a clear unsupported-cartridge error for now.
+- **D-08:** Do not make full Nintendo logo or header checksum validation a hard gate in Phase 1 unless the planner finds it trivial and low-risk. It is acceptable to parse or expose these values for later validation.
+- **D-09:** CGB-related header data is metadata only in Phase 1. It must not imply CGB execution support.
+
+### Bus Scope and Memory Behavior
+- **D-10:** Introduce a `Bus` API centered on `read8(addr: u16)` and `write8(addr: u16, value: u8)`.
+- **D-11:** Route CPU-visible memory through the Bus from the start. Future CPU code should not bypass Bus for cartridge, RAM, I/O, or interrupt-enable access.
+- **D-12:** Phase 1 Bus coverage should include cartridge ROM ranges `0000-7FFF`, WRAM `C000-DFFF`, Echo RAM `E000-FDFF` as WRAM mirror behavior, OAM `FE00-FE9F` as storage or explicitly prepared storage, unusable `FEA0-FEFF` as read `0xFF` and ignored writes, I/O `FF00-FF7F` as basic register storage/stubs, HRAM `FF80-FFFE`, and IE `FFFF`.
+- **D-13:** Writes to cartridge ROM address ranges should route to the cartridge layer. For ROM-only cartridges this can be a no-op or clear unsupported operation, but the Bus should not silently own that policy.
+- **D-14:** Defer `read16`/`write16`, CPU fetch helpers, timer side effects, PPU access restrictions, and interrupt semantics unless they are needed as small helpers for tests. Their full behavior belongs to later phases.
+
+### Testing Boundary
+- **D-15:** Add tests during Phase 1. Minimum coverage should include cartridge byte loading/parsing, unsupported and invalid input errors, ROM-only reads, Bus read/write behavior for representative ranges, Echo RAM mirror behavior, unusable range behavior, HRAM, I/O storage, and IE.
+- **D-16:** Prefer in-memory ROM byte fixtures for unit tests. Use checked-in ROM files only for lightweight smoke tests if they help, not as a full ROM execution harness.
+- **D-17:** Defer blargg/mooneye execution, serial pass/fail detection, and deterministic ROM timeouts to Phase 4.
+
+### the agent's Discretion
+- Exact Rust module names and file splits inside the locked boundary.
+- Exact custom error enum names and wording, provided CLI errors are clear and tests cover important cases.
+- Whether OAM is backed by storage in Phase 1 or represented as a prepared placeholder, provided later PPU access rules can attach cleanly.
+- Whether Nintendo logo/header checksum values are parsed now or left for a later validation pass.
+
+</decisions>
+
+<canonical_refs>
+## Canonical References
+
+**Downstream agents MUST read these before planning or implementing.**
+
+### Phase Scope
+- `.planning/ROADMAP.md` — Phase 1 goal, requirements, success criteria, and three planned work slices.
+- `.planning/REQUIREMENTS.md` — `CART-01` through `CART-04` and `BUS-01` through `BUS-04`.
+- `.planning/PROJECT.md` — DMG-first, Bus-centered, correctness-first project constraints.
+- `.planning/research/SUMMARY.md` — Research rationale for binary loading, Bus first, and dependency-free Rust core.
+
+### Codebase Context
+- `.planning/codebase/ARCHITECTURE.md` — Current single-file CLI and planned emulator core boundaries.
+- `.planning/codebase/CONCERNS.md` — Current text-ROM-loading bug, extension-only validation, and Bus/module gaps.
+- `.planning/codebase/TESTING.md` — Cargo test conventions and future ROM fixture strategy.
+- `src/main.rs` — Current CLI behavior to replace/refactor.
+
+### Project Notes
+- `docs/hot_to_proceed.md` — Local implementation direction: Bus first, CPU/device separation, test ROM validation philosophy.
+- `docs/gameboy_architecture_summary.md` — DMG memory map, cartridge header location, and subsystem constraints relevant to Bus planning.
+
+</canonical_refs>
+
+<code_context>
+## Existing Code Insights
+
+### Reusable Assets
+- `src/main.rs`: Existing CLI argument and suffix-check flow can be kept as the starting boundary, but the file read must become binary and error handling should stop panicking for normal user failures.
+- `roms/hello-world/hello-world.gb`: Useful as an optional smoke fixture for byte loading only.
+- `roms/blargg-gb-tests/` and `roms/mooneye/`: Important future validation assets, but Phase 1 should not build full execution around them.
+
+### Established Patterns
+- The crate is dependency-free Rust 2021. Keep Phase 1 within `std` unless planning finds a truly compelling reason.
+- CI already expects `cargo fmt`, `cargo clippy`, and `cargo test`; Phase 1 should add tests that fit normal Cargo patterns.
+- Project docs already prefer Bus-centered device separation, so new code should make that boundary explicit.
+
+### Integration Points
+- `src/main.rs` should call into core APIs rather than own cartridge/Bus behavior.
+- New core modules should be exposed through `src/lib.rs` so unit/integration tests and future hosts can use them.
+- Bus should connect first to cartridge and simple memory/register storage; CPU, Timer, PPU, Joypad, and APU attach in later phases.
+
+</code_context>
+
+<specifics>
+## Specific Ideas
+
+- Use a pragmatic validation ladder: binary read and header length first, header metadata parsing second, ROM-only support third.
+- Keep the first cartridge implementation honest by returning explicit unsupported errors for MBC types not yet implemented.
+- Treat `FEA0-FEFF` conservatively as unusable: reads return `0xFF`, writes ignored, unless later research/tests require nuance.
+- The planning agent should keep Phase 1 boring in the best way: small APIs, clear tests, no speculative UI/audio/rendering work.
+
+</specifics>
+
+<deferred>
+## Deferred Ideas
+
+- CPU fetch/decode/execute and cycle reporting — Phase 2.
+- Timer and interrupt semantics — Phase 3.
+- ROM execution harness and pass/fail detection — Phase 4.
+- PPU mode access restrictions and VBlank/LCD interrupt hooks — Phase 5.
+- Background/window/sprite rendering, Joypad, broader MBC support, save RAM, APU, desktop UI, and CGB behavior — v2 requirements or later phases.
+
+</deferred>
+
+---
+
+*Phase: 01-cartridge-and-bus-foundation*
+*Context gathered: 2026-05-02*

--- a/.planning/phases/01-cartridge-and-bus-foundation/01-CONTEXT.md
+++ b/.planning/phases/01-cartridge-and-bus-foundation/01-CONTEXT.md
@@ -38,7 +38,7 @@ This phase does **not** execute CPU instructions, run ROM test suites, implement
 ### Testing Boundary
 - **D-15:** Add tests during Phase 1. Minimum coverage should include cartridge byte loading/parsing, unsupported and invalid input errors, ROM-only reads, Bus read/write behavior for representative ranges, Echo RAM mirror behavior, unusable range behavior, HRAM, I/O storage, and IE.
 - **D-16:** Prefer in-memory ROM byte fixtures for unit tests. Use checked-in ROM files only for lightweight smoke tests if they help, not as a full ROM execution harness.
-- **D-17:** Defer blargg/mooneye execution, serial pass/fail detection, and deterministic ROM timeouts to Phase 4.
+- **D-17:** Defer minimal serial pass/fail capture and deterministic ROM timeouts to inserted Phase 2.1; defer broader blargg/mooneye expansion to Phase 4.
 
 ### the agent's Discretion
 - Exact Rust module names and file splits inside the locked boundary.
@@ -106,7 +106,8 @@ This phase does **not** execute CPU instructions, run ROM test suites, implement
 
 - CPU fetch/decode/execute and cycle reporting — Phase 2.
 - Timer and interrupt semantics — Phase 3.
-- ROM execution harness and pass/fail detection — Phase 4.
+- Minimal ROM execution harness and serial pass/fail detection — Phase 2.1.
+- Broader blargg/mooneye validation expansion — Phase 4.
 - PPU mode access restrictions and VBlank/LCD interrupt hooks — Phase 5.
 - Background/window/sprite rendering, Joypad, broader MBC support, save RAM, APU, desktop UI, and CGB behavior — v2 requirements or later phases.
 

--- a/.planning/phases/01-cartridge-and-bus-foundation/01-DISCUSSION-LOG.md
+++ b/.planning/phases/01-cartridge-and-bus-foundation/01-DISCUSSION-LOG.md
@@ -1,0 +1,77 @@
+# Phase 1: Cartridge and Bus Foundation - Discussion Log
+
+> **Audit trail only.** Do not use as input to planning, research, or execution agents.
+> Decisions are captured in CONTEXT.md — this log preserves the alternatives considered.
+
+**Date:** 2026-05-02
+**Phase:** 01-cartridge-and-bus-foundation
+**Areas discussed:** Module boundaries, Cartridge loading and validation, Bus scope and memory behavior, Testing boundary
+
+---
+
+## Module Boundaries
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Keep everything in `src/main.rs` | Fastest immediate patch, but prolongs the single-file prototype | |
+| Create `src/lib.rs` plus focused modules | Makes cartridge and Bus testable and reusable by future CPU/host code | ✓ |
+| You decide | Let the planner choose during implementation | |
+
+**User's choice:** Runtime fallback selected the recommended option because the interactive question tool is unavailable in this mode.
+**Notes:** This matches `.planning/research/SUMMARY.md` and project constraints: thin CLI, reusable core, Bus-centered architecture.
+
+---
+
+## Cartridge Loading and Validation
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Strict full validation | Validate logo/checksum immediately and reject anything suspicious | |
+| Pragmatic header validation | Hard-fail unreadable/too-short/unsupported basics; parse metadata; defer full logo/checksum hard gate | ✓ |
+| Minimal byte loading | Only read bytes and defer most validation | |
+
+**User's choice:** Runtime fallback selected the recommended option because the interactive question tool is unavailable in this mode.
+**Notes:** Phase 1 needs real binary ROM loading and useful errors without accidentally becoming a full compatibility-validation phase.
+
+---
+
+## Bus Scope and Memory Behavior
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Only cartridge and RAM | Smallest Bus, but too thin for later CPU work | |
+| Core DMG map skeleton | Include cartridge ROM, WRAM/Echo, OAM placeholder/storage, unusable range, I/O stubs, HRAM, IE | ✓ |
+| Full device-accurate map | Adds timer/PPU/interrupt semantics too early | |
+
+**User's choice:** Runtime fallback selected the recommended option because the interactive question tool is unavailable in this mode.
+**Notes:** This keeps Phase 1 within scope while preventing CPU code from bypassing the Bus later.
+
+---
+
+## Testing Boundary
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Unit tests only | Simple, but may miss CLI/core integration problems | |
+| Unit plus focused integration tests | Covers cartridge parsing, errors, and Bus ranges without starting ROM execution harness work | ✓ |
+| Start ROM harness now | Valuable but belongs to Phase 4 after execution foundations exist | |
+
+**User's choice:** Runtime fallback selected the recommended option because the interactive question tool is unavailable in this mode.
+**Notes:** Tests should use in-memory byte fixtures first; checked-in ROM files are optional smoke inputs, not Phase 1 pass/fail execution.
+
+---
+
+## the agent's Discretion
+
+- Exact Rust module names and layout inside the core boundary.
+- Exact custom error type names and text, as long as user-facing failures are clear.
+- Whether OAM has simple storage immediately or a prepared placeholder.
+- Whether logo/checksum fields are parsed now or deferred.
+
+## Deferred Ideas
+
+- CPU execution and cycle reporting.
+- Timer and interrupt behavior.
+- ROM pass/fail harness.
+- PPU rendering and PPU access restrictions beyond simple Bus scaffolding.
+- Broad MBC support, save RAM, CGB, audio, and desktop UI.

--- a/.planning/phases/01-cartridge-and-bus-foundation/01-DISCUSSION-LOG.md
+++ b/.planning/phases/01-cartridge-and-bus-foundation/01-DISCUSSION-LOG.md
@@ -54,7 +54,7 @@
 |--------|-------------|----------|
 | Unit tests only | Simple, but may miss CLI/core integration problems | |
 | Unit plus focused integration tests | Covers cartridge parsing, errors, and Bus ranges without starting ROM execution harness work | ✓ |
-| Start ROM harness now | Valuable but belongs to Phase 4 after execution foundations exist | |
+| Start ROM harness now | Valuable, but minimal serial ROM harness now belongs to inserted Phase 2.1 after CPU foundation; broader blargg/mooneye expansion remains Phase 4 | |
 
 **User's choice:** Runtime fallback selected the recommended option because the interactive question tool is unavailable in this mode.
 **Notes:** Tests should use in-memory byte fixtures first; checked-in ROM files are optional smoke inputs, not Phase 1 pass/fail execution.

--- a/.planning/phases/01-cartridge-and-bus-foundation/01-PATTERNS.md
+++ b/.planning/phases/01-cartridge-and-bus-foundation/01-PATTERNS.md
@@ -1,0 +1,37 @@
+# Phase 1 Pattern Map: Cartridge and Bus Foundation
+
+**Phase:** 01-cartridge-and-bus-foundation
+**Mapped:** 2026-05-02
+
+## Existing Patterns To Preserve
+
+- Dependency-free Rust crate: keep implementation in Rust standard library and avoid adding dependencies.
+- Thin CLI boundary: keep user argument handling and display in `src/main.rs`.
+- Cargo-native tests: add ordinary Rust unit tests and verify with `cargo test`.
+- Bus-centered architecture: follow project docs that route CPU-visible memory through a central Bus.
+
+## File Pattern Mapping
+
+| New or Modified File | Closest Existing Pattern | Planning Guidance |
+|----------------------|--------------------------|-------------------|
+| `src/main.rs` | Current CLI file | Keep it small. It should parse arguments, reject unsupported path suffixes, call core cartridge loading, print a concise success message or error, and avoid hardware logic. |
+| `src/lib.rs` | Standard Rust library module root | Add module exports only. Do not place implementation logic here. |
+| `src/cartridge.rs` | New core module | Use explicit constants for header offsets, custom error enums with `Display`, and inline unit tests with in-memory ROM byte fixtures. |
+| `src/bus.rs` | New core module | Use a `Bus` struct with fixed-size arrays for simple memory regions and tests for each required address range. |
+
+## Anti-Patterns To Avoid
+
+- Do not keep using `read_to_string` for ROM data.
+- Do not add CPU, timer, interrupt, PPU, APU, or UI behavior in Phase 1.
+- Do not silently accept unknown cartridge type or size codes.
+- Do not make the Bus own ROM write policy; route ROM writes to the cartridge layer.
+- Do not build broad checked-in ROM execution tests before the execution harness phase.
+
+## Execution Dependencies
+
+Plan ordering should be sequential:
+
+- `01-01` creates the library/cartridge loading foundation and CLI handoff.
+- `01-02` builds on cartridge loading to parse headers and expose ROM-only reads.
+- `01-03` builds on the cartridge representation to add Bus routing and memory range tests.
+

--- a/.planning/phases/01-cartridge-and-bus-foundation/01-RESEARCH.md
+++ b/.planning/phases/01-cartridge-and-bus-foundation/01-RESEARCH.md
@@ -1,0 +1,176 @@
+# Phase 1 Research: Cartridge and Bus Foundation
+
+**Phase:** 01-cartridge-and-bus-foundation
+**Researched:** 2026-05-02
+**Status:** RESEARCH COMPLETE
+
+## Scope
+
+Phase 1 is a foundation slice. It should replace text-based ROM loading with binary cartridge loading, parse the core Game Boy cartridge header fields, support ROM-only cartridge reads, and introduce a Bus API for CPU-visible 8-bit reads and writes.
+
+This phase should not execute CPU instructions, run blargg/mooneye ROMs, implement timer or interrupt side effects, render pixels, support broad MBC behavior, or add a UI/audio host.
+
+## Current Code Facts
+
+- `src/main.rs` is the only Rust source file.
+- `src/main.rs` currently uses `std::fs::read_to_string`, which is wrong for arbitrary `.gb` or `.gbc` ROM bytes.
+- The crate has no runtime dependencies beyond Rust standard library usage.
+- There are no source-level tests yet.
+- ROM fixtures exist under `roms/`, but Phase 1 should mostly use in-memory byte fixtures so tests stay fast and focused.
+
+## Implementation Shape
+
+Recommended files:
+
+- `src/lib.rs`: expose reusable core modules.
+- `src/cartridge.rs`: own ROM byte loading, cartridge metadata, validation, and ROM-only reads.
+- `src/bus.rs`: own DMG address routing and simple backing storage for Phase 1 memory ranges.
+- `src/main.rs`: remain a thin CLI boundary that validates path shape, calls cartridge APIs, and prints clear errors.
+
+Recommended module exports:
+
+- `pub mod cartridge;`
+- `pub mod bus;`
+
+The CLI should import from the library crate rather than embedding cartridge or Bus logic in `main`.
+
+## Cartridge Header Notes
+
+Minimum useful ROM length for Phase 1 is `0x150` bytes, because the cartridge header ends at `0x014F`.
+
+Header fields to parse:
+
+- Entry point bytes: `0x0100..=0x0103`
+- Nintendo logo bytes, optional metadata only: `0x0104..=0x0133`
+- Title bytes: `0x0134..=0x0143`
+- CGB flag metadata: `0x0143`
+- Cartridge type: `0x0147`
+- ROM size code: `0x0148`
+- RAM size code: `0x0149`
+- Header checksum metadata, optional: `0x014D`
+- Global checksum metadata, optional: `0x014E..=0x014F`
+
+Phase 1 should accept cartridge type `0x00` as ROM-only and return a clear unsupported-cartridge error for other types. Later MBC support belongs outside this phase.
+
+Useful ROM size code mapping for Phase 1:
+
+- `0x00`: 32 KiB
+- `0x01`: 64 KiB
+- `0x02`: 128 KiB
+- `0x03`: 256 KiB
+- `0x04`: 512 KiB
+- `0x05`: 1 MiB
+- `0x06`: 2 MiB
+- `0x07`: 4 MiB
+- `0x08`: 8 MiB
+
+Useful RAM size code mapping for Phase 1:
+
+- `0x00`: no RAM
+- `0x01`: 2 KiB
+- `0x02`: 8 KiB
+- `0x03`: 32 KiB
+- `0x04`: 128 KiB
+- `0x05`: 64 KiB
+
+Unknown or unsupported size codes should return clear errors instead of silently guessing.
+
+## Cartridge API Notes
+
+Recommended types:
+
+- `Cartridge`
+- `CartridgeHeader`
+- `CartridgeType`
+- `CartridgeError`
+
+Recommended constructors and helpers:
+
+- `Cartridge::from_bytes(bytes: Vec<u8>) -> Result<Self, CartridgeError>`
+- `Cartridge::read_rom(&self, address: u16) -> u8`
+- `Cartridge::write_rom(&mut self, address: u16, value: u8)` as a ROM-only no-op or explicit policy hook
+- `load_cartridge_file(path: impl AsRef<Path>) -> Result<Cartridge, CartridgeError>`
+
+`CartridgeError` should implement `std::fmt::Display` and should be useful to CLI users. It can wrap `std::io::Error` for filesystem failures.
+
+## Bus Memory Map Notes
+
+Phase 1 Bus should expose:
+
+- `Bus::new(cartridge: Cartridge) -> Self`
+- `read8(&self, addr: u16) -> u8`
+- `write8(&mut self, addr: u16, value: u8)`
+
+Recommended backing storage:
+
+- WRAM: `[u8; 0x2000]` for `0xC000..=0xDFFF`
+- OAM placeholder storage: `[u8; 0xA0]` for `0xFE00..=0xFE9F`
+- I/O storage or stubs: `[u8; 0x80]` for `0xFF00..=0xFF7F`
+- HRAM: `[u8; 0x7F]` for `0xFF80..=0xFFFE`
+- IE: `u8` for `0xFFFF`
+
+Address routing:
+
+- `0x0000..=0x7FFF`: cartridge ROM reads; writes route to cartridge policy.
+- `0xC000..=0xDFFF`: WRAM.
+- `0xE000..=0xFDFF`: Echo RAM mirror of WRAM.
+- `0xFE00..=0xFE9F`: OAM placeholder storage.
+- `0xFEA0..=0xFEFF`: unusable; reads return `0xFF`, writes ignored.
+- `0xFF00..=0xFF7F`: basic I/O storage or explicit stubs.
+- `0xFF80..=0xFFFE`: HRAM.
+- `0xFFFF`: interrupt enable register.
+
+VRAM and external RAM can be left as prepared storage or default behavior only if needed, but the required success criteria focus on cartridge ROM, WRAM, HRAM, IE, I/O, and representative unusable ranges.
+
+## Test Strategy
+
+Use focused unit tests inside `src/cartridge.rs` and `src/bus.rs`.
+
+Minimum tests:
+
+- Loading/parsing rejects ROMs shorter than `0x150`.
+- Header parsing exposes title, type, ROM size, RAM size, and entry bytes.
+- Unsupported cartridge type returns a clear error.
+- Unsupported ROM/RAM size code returns a clear error.
+- ROM-only cartridge reads return bytes from `0x0000..=0x7FFF`.
+- Bus reads cartridge ROM through the cartridge layer.
+- WRAM writes can be read back.
+- Echo RAM mirrors WRAM.
+- OAM placeholder range stores values or behaves consistently with the chosen placeholder policy.
+- Unusable range reads `0xFF` and ignores writes.
+- I/O, HRAM, and IE read/write behavior is covered.
+
+Do not build a ROM execution harness in Phase 1. Save blargg/mooneye execution and pass/fail signaling for Phase 4.
+
+## Verification Commands
+
+Run after each plan execution:
+
+```bash
+cargo fmt --all
+cargo test
+```
+
+Useful optional smoke check after Plan 01 or Plan 02:
+
+```bash
+cargo run -- roms/hello-world/hello-world.gb
+```
+
+## Threat Model
+
+ROM files are untrusted binary inputs. Implementation should avoid text decoding, unchecked indexing, panics on expected user failures, and silent interpretation of unknown header codes.
+
+Mitigations:
+
+- Use `std::fs::read` for bytes.
+- Check `bytes.len() >= 0x150` before header indexing.
+- Use safe slice access and explicit constants for offsets.
+- Return custom errors for too-short ROMs, unsupported types, and unsupported size codes.
+- Keep CLI errors human-readable and avoid `expect` for ordinary file problems.
+
+Residual risk:
+
+- Phase 1 does not validate Nintendo logo or header checksum as hard gates.
+- Phase 1 does not prove broad ROM compatibility because CPU execution and ROM harnessing are deferred.
+

--- a/.planning/phases/01-cartridge-and-bus-foundation/01-RESEARCH.md
+++ b/.planning/phases/01-cartridge-and-bus-foundation/01-RESEARCH.md
@@ -140,7 +140,7 @@ Minimum tests:
 - Unusable range reads `0xFF` and ignores writes.
 - I/O, HRAM, and IE read/write behavior is covered.
 
-Do not build a ROM execution harness in Phase 1. Save blargg/mooneye execution and pass/fail signaling for Phase 4.
+Do not build a ROM execution harness in Phase 1. Save minimal serial pass/fail signaling and deterministic ROM timeouts for inserted Phase 2.1, and broader blargg/mooneye validation expansion for Phase 4.
 
 ## Verification Commands
 
@@ -173,4 +173,3 @@ Residual risk:
 
 - Phase 1 does not validate Nintendo logo or header checksum as hard gates.
 - Phase 1 does not prove broad ROM compatibility because CPU execution and ROM harnessing are deferred.
-

--- a/.planning/phases/01-cartridge-and-bus-foundation/01-REVIEW.md
+++ b/.planning/phases/01-cartridge-and-bus-foundation/01-REVIEW.md
@@ -1,0 +1,39 @@
+---
+phase: 01-cartridge-and-bus-foundation
+status: clean
+depth: standard
+files_reviewed: 4
+findings:
+  critical: 0
+  warning: 0
+  info: 0
+  total: 0
+reviewed: 2026-05-02
+---
+
+# Phase 01 Code Review
+
+## Scope
+
+- `src/lib.rs`
+- `src/main.rs`
+- `src/cartridge.rs`
+- `src/bus.rs`
+
+## Result
+
+No issues found.
+
+## Checks
+
+- `cargo fmt --all -- --check` passed.
+- `cargo test` passed with 17 tests.
+- `cargo clippy -- -D warnings` passed.
+
+## Notes
+
+- Cartridge parsing checks minimum ROM length before header slicing.
+- Unsupported cartridge type and unsupported ROM/RAM size codes return explicit errors.
+- CLI error paths return failure exit codes and no longer panic on expected user input failures.
+- Bus routing delegates cartridge ROM reads and writes to `Cartridge`.
+- Out-of-scope helpers such as `read16`, `write16`, CPU fetch helpers, timer side effects, PPU access restrictions, and ROM harness execution were not introduced.

--- a/.planning/phases/01-cartridge-and-bus-foundation/01-VERIFICATION.md
+++ b/.planning/phases/01-cartridge-and-bus-foundation/01-VERIFICATION.md
@@ -18,18 +18,18 @@ Passed. Phase 1 achieves its goal: the user can load ROM bytes into a cartridge 
 ## Automated Checks
 
 - `cargo fmt --all -- --check` passed.
-- `cargo test` passed with 17 tests.
+- `cargo test` passed with 23 tests: 17 core unit tests and 6 CLI integration tests.
 - `cargo test cartridge` passed with 11 cartridge tests.
 - `cargo test bus` passed with 6 Bus tests.
 - `cargo clippy -- -D warnings` passed.
-- CLI smoke checks covered valid ROM loading, invalid suffix, missing file, unreadable file, and too-short ROM behavior.
+- CLI integration tests cover valid ROM loading, case-insensitive `.gbc` handling, missing argument usage, invalid suffix, missing file, and too-short ROM behavior.
 
 ## Requirement Verification
 
 | Requirement | Status | Evidence |
 |-------------|--------|----------|
-| CART-01 | Passed | `src/main.rs` delegates to `game_girl::cartridge::load_rom_file`, which reads bytes through `std::fs::read`; hello-world ROM smoke check prints `Loaded ROM: 32768 bytes`. |
-| CART-02 | Passed | CLI returns non-zero errors for missing paths, unreadable files, invalid suffixes, and too-short ROMs; cartridge errors implement `Display`. |
+| CART-01 | Passed | `src/main.rs` delegates to `game_girl::cartridge::load_rom_file`, which reads bytes through `std::fs::read`; CLI integration tests assert valid ROM output. |
+| CART-02 | Passed | CLI integration tests assert non-zero errors for missing arguments, missing files, invalid suffixes, and too-short ROMs; cartridge errors implement `Display`. |
 | CART-03 | Passed | `CartridgeHeader` exposes title, cartridge type/code, ROM/RAM size/code, entry point, logo/header bytes, CGB flag, header checksum, and global checksum. |
 | CART-04 | Passed | `Cartridge::from_bytes` constructs ROM-only cartridges and `read_rom` covers fixed ROM range reads. |
 | CART-05 | Passed | Non-ROM-only type codes are parsed and returned as `UnsupportedCartridgeType(code)`. |
@@ -40,8 +40,8 @@ Passed. Phase 1 achieves its goal: the user can load ROM bytes into a cartridge 
 
 ## Success Criteria
 
-1. CLI with a `.gb` path reads binary bytes without UTF-8 assumptions: Passed.
-2. Clear errors for missing, unreadable, too-short, or invalid ROM inputs: Passed.
+1. CLI with a `.gb` path reads binary bytes without UTF-8 assumptions: Passed with integration coverage.
+2. Clear errors for missing, unreadable, too-short, or invalid ROM inputs: Passed with integration coverage.
 3. Cartridge header parsing exposes title, type, ROM size, RAM size, and entry/header data in tests: Passed.
 4. Non-ROM-only cartridge types report `UnsupportedCartridgeType`: Passed.
 5. Bus tests cover cartridge ROM, WRAM, HRAM, IE, I/O, and representative unusable ranges: Passed.

--- a/.planning/phases/01-cartridge-and-bus-foundation/01-VERIFICATION.md
+++ b/.planning/phases/01-cartridge-and-bus-foundation/01-VERIFICATION.md
@@ -1,0 +1,74 @@
+---
+phase: 01-cartridge-and-bus-foundation
+status: passed
+verified: 2026-05-02
+requirements_verified: [CART-01, CART-02, CART-03, CART-04, CART-05, BUS-01, BUS-02, BUS-03, BUS-04]
+must_haves_verified: 21
+must_haves_total: 21
+human_verification: []
+gaps: []
+---
+
+# Phase 01 Verification: Cartridge and Bus Foundation
+
+## Verdict
+
+Passed. Phase 1 achieves its goal: the user can load ROM bytes into a cartridge path, construct/read ROM-only cartridge data, and exercise a Bus API for the core DMG memory ranges required by the roadmap.
+
+## Automated Checks
+
+- `cargo fmt --all -- --check` passed.
+- `cargo test` passed with 17 tests.
+- `cargo test cartridge` passed with 11 cartridge tests.
+- `cargo test bus` passed with 6 Bus tests.
+- `cargo clippy -- -D warnings` passed.
+- CLI smoke checks covered valid ROM loading, invalid suffix, missing file, unreadable file, and too-short ROM behavior.
+
+## Requirement Verification
+
+| Requirement | Status | Evidence |
+|-------------|--------|----------|
+| CART-01 | Passed | `src/main.rs` delegates to `game_girl::cartridge::load_rom_file`, which reads bytes through `std::fs::read`; hello-world ROM smoke check prints `Loaded ROM: 32768 bytes`. |
+| CART-02 | Passed | CLI returns non-zero errors for missing paths, unreadable files, invalid suffixes, and too-short ROMs; cartridge errors implement `Display`. |
+| CART-03 | Passed | `CartridgeHeader` exposes title, cartridge type/code, ROM/RAM size/code, entry point, logo/header bytes, CGB flag, header checksum, and global checksum. |
+| CART-04 | Passed | `Cartridge::from_bytes` constructs ROM-only cartridges and `read_rom` covers fixed ROM range reads. |
+| CART-05 | Passed | Non-ROM-only type codes are parsed and returned as `UnsupportedCartridgeType(code)`. |
+| BUS-01 | Passed | `Bus::read8(addr: u16)` and `Bus::write8(addr: u16, value: u8)` are implemented. |
+| BUS-02 | Passed | Bus routes cartridge ROM, WRAM, HRAM, IE, and I/O reads. |
+| BUS-03 | Passed | Bus routes writable memory/I/O writes and delegates ROM-range writes to `Cartridge::write_rom`. |
+| BUS-04 | Passed | Bus tests cover representative valid, mirrored, unusable, and unmapped ranges. |
+
+## Success Criteria
+
+1. CLI with a `.gb` path reads binary bytes without UTF-8 assumptions: Passed.
+2. Clear errors for missing, unreadable, too-short, or invalid ROM inputs: Passed.
+3. Cartridge header parsing exposes title, type, ROM size, RAM size, and entry/header data in tests: Passed.
+4. Non-ROM-only cartridge types report `UnsupportedCartridgeType`: Passed.
+5. Bus tests cover cartridge ROM, WRAM, HRAM, IE, I/O, and representative unusable ranges: Passed.
+
+## Must-Haves
+
+All plan `must_haves.truths` were verified against code and tests:
+
+- Reusable core modules exist in `src/lib.rs`, `src/cartridge.rs`, and `src/bus.rs`.
+- CLI logic stays in `src/main.rs` and delegates loading to the core.
+- No new dependencies were added.
+- ROM loading is byte-oriented and no `read_to_string`/ROM-loading `expect` path remains.
+- Header parsing is bounds-checked before slicing.
+- ROM-only cartridges construct and read; unsupported type and size codes fail explicitly.
+- Nintendo logo, checksum, and CGB flag are metadata only.
+- Bus routes Phase 1 address ranges through `read8`/`write8`.
+- ROM writes route to the cartridge layer.
+- Out-of-scope helpers and ROM execution harness behavior remain deferred.
+
+## Non-Blocking Notes
+
+- Codebase drift gate reported stale codebase-map context for `.gitattributes`, `.gitignore`, and `AGENTS.md`. This is advisory and unrelated to Phase 1 source correctness.
+- Security enforcement is enabled and no phase security audit has been run yet. Run `$gsd-secure-phase 1` before advancing if you want the formal security gate artifact.
+
+## Gaps
+
+None.
+
+---
+*Verified: 2026-05-02*

--- a/.planning/quick/260502-gih-incorporate-roadmap-feedback-insert-earl/260502-gih-PLAN.md
+++ b/.planning/quick/260502-gih-incorporate-roadmap-feedback-insert-earl/260502-gih-PLAN.md
@@ -1,0 +1,39 @@
+---
+quick_id: 260502-gih
+type: quick
+status: complete
+date: 2026-05-02
+description: "Incorporate roadmap feedback: insert early minimal serial ROM validation harness, narrow CPU phase scope, and clarify ROM-only/MBC and post-boot assumptions"
+---
+
+# Quick Task 260502-gih Plan
+
+## Objective
+
+Incorporate roadmap feedback so validation appears earlier, CPU implementation is staged more safely, and v1.0 assumptions around cartridge support and boot state are explicit.
+
+## Tasks
+
+### Task 1: Update roadmap phase sequencing
+
+**Files**: `.planning/ROADMAP.md`
+
+**Action**: Insert Phase 2.1 for minimal serial ROM validation, split Phase 2 CPU work into smaller plan slices, rename Phase 4 as validation harness expansion, and update execution order/progress counts.
+
+**Verify**: Roadmap shows `1 -> 2 -> 2.1 -> 3 -> 4 -> 5` and Phase 2 has five plans.
+
+### Task 2: Update requirements and traceability
+
+**Files**: `.planning/REQUIREMENTS.md`, `.planning/PROJECT.md`, `.planning/STATE.md`
+
+**Action**: Add explicit requirements for non-ROM-only cartridge rejection, post-boot DMG startup, serial test output capture, and expanded blargg/mooneye validation. Update traceability and state totals.
+
+**Verify**: Requirement coverage totals match mapped requirements and Phase 2.1 owns `SERIAL-01`, `TEST-02`, and `TEST-03`.
+
+### Task 3: Remove stale Phase 4-only harness references
+
+**Files**: `.planning/phases/01-cartridge-and-bus-foundation/*.md`
+
+**Action**: Align existing Phase 1 context/research/plan artifacts so serial pass/fail and deterministic ROM timeout work now points to Phase 2.1 while broader blargg/mooneye expansion remains Phase 4.
+
+**Verify**: Search results no longer claim that serial pass/fail detection must wait until Phase 4.

--- a/.planning/quick/260502-gih-incorporate-roadmap-feedback-insert-earl/260502-gih-SUMMARY.md
+++ b/.planning/quick/260502-gih-incorporate-roadmap-feedback-insert-earl/260502-gih-SUMMARY.md
@@ -1,0 +1,30 @@
+---
+quick_id: 260502-gih
+status: complete
+date: 2026-05-02
+description: "Incorporate roadmap feedback: insert early minimal serial ROM validation harness, narrow CPU phase scope, and clarify ROM-only/MBC and post-boot assumptions"
+---
+
+# Quick Task 260502-gih Summary
+
+## Result
+
+Roadmap feedback has been incorporated into the planning artifacts.
+
+## Changes
+
+- Inserted `Phase 2.1: Minimal Serial and ROM Test Harness INSERTED` between CPU foundation and timer/interrupt work.
+- Split Phase 2 CPU work into five smaller plans covering registers/fetch, basic loads, arithmetic/logical flags, control-flow/stack helpers, and CB-prefix deferral/skeleton.
+- Renamed Phase 4 to `Automated Validation Harness Expansion` so it expands the early harness instead of introducing validation too late.
+- Added explicit v1.0 requirements for ROM-only/MBC handling, post-boot startup without Nintendo boot ROM emulation, serial test output capture, and capability-gated blargg/mooneye validation.
+- Updated Phase 1 context/research/plan references that previously deferred serial pass/fail detection all the way to Phase 4.
+
+## Verification
+
+- Checked roadmap execution order and progress table.
+- Checked requirements traceability and coverage totals.
+- Searched planning artifacts for stale Phase 4-only serial/ROM harness references.
+
+## Notes
+
+No Rust code changed, so Cargo tests were not run for this docs-only quick task.

--- a/.planning/research/ARCHITECTURE.md
+++ b/.planning/research/ARCHITECTURE.md
@@ -1,0 +1,213 @@
+# Architecture Research
+
+**Domain:** Rust DMG Game Boy emulator
+**Researched:** 2026-05-02
+**Confidence:** HIGH
+
+## Standard Architecture
+
+### System Overview
+
+```text
++-------------------------------------------------------------+
+|                         Host / CLI                           |
+|  ROM path, errors, future display/audio/input adapters        |
++------------------------------+------------------------------+
+                               |
+                               v
++-------------------------------------------------------------+
+|                       Emulator Core                           |
+|  Step loop, clocks, frame/test execution control              |
++------------------------------+------------------------------+
+                               |
+                               v
++-------------------------------------------------------------+
+|                            Bus                                |
+|  16-bit address routing, memory map, device coordination      |
++----------+-----------+-----------+-----------+---------------+
+           |           |           |           |
+           v           v           v           v
+       Cartridge      CPU        Timer        PPU       Joypad/APU later
+       ROM/MBC       regs/op    DIV/TIMA     modes      IO registers
+```
+
+### Component Responsibilities
+
+| Component | Responsibility | Typical Implementation |
+|-----------|----------------|------------------------|
+| CLI | Parse ROM path, load bytes, format top-level errors | Thin `src/main.rs` boundary |
+| Cartridge | Own ROM bytes, parse header, expose ROM/RAM/MBC reads/writes | `Cartridge` struct plus mapper enum/trait |
+| Bus | Route reads/writes for `0000-FFFF` | `Bus` struct containing cartridge, RAM, I/O devices |
+| CPU | Own registers, flags, instruction decode/execute, cycles | `Cpu` struct with step method returning elapsed cycles |
+| Timer | Model DIV/TIMA/TMA/TAC and timer interrupt requests | Internal system counter plus I/O register methods |
+| Interrupts | Track `IE`, `IF`, `IME`, delayed `ei`, vector dispatch | CPU/bus shared state with explicit service step |
+| PPU | Track modes, LY, VRAM/OAM access, future rendering | Start with mode timing before pixels |
+| Test Harness | Run unit and ROM-level checks | Cargo tests plus helper runner |
+
+## Recommended Project Structure
+
+```text
+src/
+|-- main.rs              # CLI shell
+|-- lib.rs               # Emulator core public module root
+|-- cartridge.rs         # ROM bytes, header, mapper dispatch
+|-- bus.rs               # Address map and device read/write routing
+|-- cpu/
+|   |-- mod.rs           # CPU state and step loop
+|   |-- registers.rs     # Register pairs and flags
+|   |-- opcodes.rs       # Decode table or opcode dispatch
+|   `-- instructions.rs  # Instruction family helpers
+|-- timer.rs             # DIV/TIMA/TMA/TAC behavior
+|-- interrupts.rs        # IE/IF/IME and vectors
+|-- ppu.rs               # PPU mode state, VRAM/OAM restrictions
+`-- joypad.rs            # Input register state, later phase
+tests/
+|-- common/              # Future ROM harness helpers
+|-- cartridge.rs
+|-- cpu_smoke.rs
+`-- timer.rs
+```
+
+### Structure Rationale
+
+- **`src/lib.rs`:** Lets tests and future hosts use the emulator core without going through CLI code.
+- **`src/main.rs`:** Keeps user-facing argument parsing separate from hardware rules.
+- **`src/bus.rs`:** Gives all memory-mapped behavior one home instead of scattering address checks through CPU code.
+- **`src/cpu/`:** CPU implementation is large enough to justify submodules from the start.
+- **`tests/common/`:** A ROM harness will need shared timeout/pass-fail utilities.
+
+## Architectural Patterns
+
+### Pattern 1: Thin Host, Reusable Core
+
+**What:** Keep CLI/window/audio concerns outside the emulator hardware model.
+**When to use:** Immediately.
+**Trade-offs:** Slightly more structure up front, but much easier testing.
+
+```rust
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let rom = std::fs::read(path)?;
+    let cart = game_girl::Cartridge::from_bytes(rom)?;
+    let mut emu = game_girl::Emulator::new(cart);
+    emu.step();
+    Ok(())
+}
+```
+
+### Pattern 2: Bus-Owned Memory Map
+
+**What:** CPU asks the bus for reads/writes; the bus routes to cartridge/RAM/I/O devices.
+**When to use:** Before implementing instruction execution.
+**Trade-offs:** More explicit device ownership decisions, but prevents CPU from knowing too much.
+
+```rust
+let opcode = bus.read8(cpu.pc);
+cpu.pc = cpu.pc.wrapping_add(1);
+```
+
+### Pattern 3: Cycle-Returning CPU Step
+
+**What:** CPU execution returns elapsed machine cycles or dots so timers/PPU can advance.
+**When to use:** As soon as CPU stepping exists.
+**Trade-offs:** More bookkeeping per instruction, but avoids bolting timing on later.
+
+## Data Flow
+
+### ROM Execution Flow
+
+```text
+CLI path
+    -> fs::read bytes
+    -> Cartridge::from_bytes
+    -> Emulator::new
+    -> Cpu::step(&mut Bus)
+    -> Bus read/write
+    -> Cartridge/RAM/Timer/Interrupts/PPU/Joypad
+    -> elapsed cycles advance devices
+```
+
+### State Management
+
+```text
+Emulator
+|-- Cpu
+`-- Bus
+    |-- Cartridge
+    |-- Wram/Hram
+    |-- Timer
+    |-- InterruptController or IE/IF state
+    |-- Ppu
+    `-- Joypad later
+```
+
+### Key Data Flows
+
+1. **Opcode fetch:** CPU reads `PC` through Bus, so cartridge mapping is honored.
+2. **I/O register write:** CPU writes through Bus, which updates timer/PPU/joypad/interrupt state.
+3. **Timer tick:** CPU cycles advance system counter; overflow sets timer interrupt request in `IF`.
+4. **ROM test result:** Harness observes serial/link/debug-break behavior or another defined pass/fail marker.
+
+## Scaling Considerations
+
+| Scale | Architecture Adjustments |
+|-------|--------------------------|
+| First executable ROM | Dependency-free core, unit tests, simple CLI |
+| Many test ROMs | Add ROM harness helpers, timeouts, grouped ignored/slow tests |
+| Interactive emulator | Add host display/input/audio adapters outside core |
+| Wider compatibility | Add MBC variants, PPU pixel pipeline detail, APU, CGB behind explicit model selection |
+
+### Scaling Priorities
+
+1. **First bottleneck:** Correctness visibility. Fix by adding tests before broad feature work.
+2. **Second bottleneck:** Instruction dispatch maintainability. Fix by grouping opcode implementation and tests.
+3. **Third bottleneck:** Timing coupling. Fix by making cycle advancement a first-class API.
+
+## Anti-Patterns
+
+### Anti-Pattern 1: CPU Owns the Whole Machine
+
+**What people do:** Put cartridge, RAM, timer, interrupts, and graphics logic inside CPU methods.
+**Why it's wrong:** Address routing and device timing become impossible to test independently.
+**Do this instead:** CPU owns CPU state; Bus owns memory routing and device access.
+
+### Anti-Pattern 2: Demo-Driven Correctness
+
+**What people do:** Run one simple ROM and treat visible output as correctness.
+**Why it's wrong:** Game Boy edge cases often fail only under targeted tests.
+**Do this instead:** Make blargg/mooneye milestones part of the roadmap.
+
+### Anti-Pattern 3: Timing After the Fact
+
+**What people do:** Implement opcodes first, then add cycles later.
+**Why it's wrong:** Timer, interrupts, PPU access, and HALT behavior depend on timing.
+**Do this instead:** Return cycles from instruction execution from the beginning.
+
+## Integration Points
+
+### External Services
+
+| Service | Integration Pattern | Notes |
+|---------|---------------------|-------|
+| None | n/a | Emulator core should not require network services |
+
+### Internal Boundaries
+
+| Boundary | Communication | Notes |
+|----------|---------------|-------|
+| CLI <-> Core | Construct objects, call APIs, handle `Result` | No hardware logic in CLI |
+| CPU <-> Bus | `read8`, `write8`, maybe `read16` helpers | CPU should not bypass Bus |
+| Bus <-> Cartridge | Mapper read/write methods | ROM writes may change MBC state |
+| CPU/Bus <-> Timer/Interrupts | Cycle advancement and I/O registers | Timer overflow sets `IF` bit |
+| Bus <-> PPU | VRAM/OAM reads/writes and mode state | Access restrictions need PPU mode |
+
+## Sources
+
+- https://gbdev.io/pandocs/Memory_Map.html - memory regions, cartridge header, external hardware/MBC notes
+- https://gbdev.io/pandocs/Timer_Obscure_Behaviour.html - internal counter and timer overflow behavior
+- https://gbdev.io/pandocs/Interrupts.html - `IME`, `IE`, `IF`, delayed `ei`
+- `docs/gameboy_architecture_summary.md` - local DMG architecture summary
+- `.planning/codebase/ARCHITECTURE.md` - current repo architecture
+
+---
+*Architecture research for: Rust DMG Game Boy emulator*
+*Researched: 2026-05-02*

--- a/.planning/research/FEATURES.md
+++ b/.planning/research/FEATURES.md
@@ -1,0 +1,122 @@
+# Feature Research
+
+**Domain:** Rust DMG Game Boy emulator
+**Researched:** 2026-05-02
+**Confidence:** HIGH
+
+## Feature Landscape
+
+### Table Stakes (Users Expect These)
+
+| Feature | Why Expected | Complexity | Notes |
+|---------|--------------|------------|-------|
+| Binary ROM loading | Emulator must consume `.gb` bytes, not text | LOW | Replace `read_to_string` with `fs::read`; parse header from `0x0100-0x014F` |
+| Cartridge header parsing | Needed to know title, ROM size, RAM size, and mapper type | MEDIUM | Pan Docs places cartridge header in the first ROM bank |
+| DMG memory map and bus | CPU-visible devices are selected by address | MEDIUM | Required before CPU can execute real ROM reads/writes |
+| CPU registers and fetch/decode/execute | Core of every emulator | HIGH | Start with register model and a small instruction subset |
+| CPU flags and stack behavior | Required for control flow and arithmetic correctness | HIGH | Small mistakes cascade into test failures |
+| Timer and interrupts | Many games and tests rely on timing and `IF`/`IE`/`IME` behavior | HIGH | Use internal counter model from the start |
+| ROM test harness | Existing fixtures need automated pass/fail checks | MEDIUM | Start with targeted unit tests, then ROM-level harness |
+
+### Differentiators (Competitive Advantage)
+
+| Feature | Value Proposition | Complexity | Notes |
+|---------|-------------------|------------|-------|
+| Test-ROM-driven milestones | Makes progress measurable and prevents demo-only correctness | MEDIUM | Use local blargg/mooneye assets as phase gates |
+| Clear hardware module boundaries | Makes future timing fixes safer | MEDIUM | Bus, CPU, cartridge, timer, interrupts, PPU, joypad |
+| DMG-first precision notes | Avoids mixing DMG/CGB behavior accidentally | LOW | Keep CGB decisions out of v1 requirements |
+
+### Anti-Features (Commonly Requested, Often Problematic)
+
+| Feature | Why Requested | Why Problematic | Alternative |
+|---------|---------------|-----------------|-------------|
+| Full UI first | It feels like a visible emulator quickly | Encourages drawing before execution correctness exists | Build core and tests first, add host UI later |
+| Implement all instructions in one giant pass | Seems faster than phased work | Hard to debug flags, cycles, and decode issues | Implement and test instruction families incrementally |
+| CGB support from day one | More complete emulator story | Adds banked VRAM/WRAM, palettes, speed switching, and model differences too early | Keep architecture extensible but scope v1 to DMG |
+| Audio early | Fun and visible | APU timing is its own complex subsystem | Defer until CPU/bus/timer/PPU foundations are stable |
+
+## Feature Dependencies
+
+```text
+Binary ROM loading
+    requires -> Cartridge header parsing
+        requires -> Bus memory mapping
+            requires -> CPU fetch/decode/execute
+                requires -> Flags, stack, jumps, calls
+                    enhances -> ROM test harness
+
+Timer and interrupt state
+    requires -> Bus I/O registers
+    enhances -> CPU test ROM compatibility
+
+PPU mode timing
+    requires -> Bus memory mapping
+    enhances -> VRAM/OAM access correctness
+```
+
+### Dependency Notes
+
+- **ROM loading requires header parsing:** The emulator needs cartridge metadata before it can choose mapper behavior.
+- **Bus requires cartridge and memory regions:** CPU execution must read opcodes from the cartridge address space and write device registers through one boundary.
+- **Timer/interrupts require bus I/O registers:** `IF`, `IE`, `DIV`, `TIMA`, `TMA`, and `TAC` are memory-mapped.
+- **ROM harness depends on execution loop:** Test ROMs become useful once the CPU can step and expose pass/fail signals.
+
+## MVP Definition
+
+### Launch With (v1)
+
+- [ ] Binary ROM byte loading and basic cartridge header parsing - real ROM input starts here
+- [ ] DMG bus and memory map skeleton - all hardware access needs one route
+- [ ] CPU registers and initial instruction execution loop - enables first executable behavior
+- [ ] Focused CPU instruction groups with unit tests - prevents a fragile giant opcode table
+- [ ] Timer/interrupt registers and initial timing model - required for meaningful tests
+- [ ] ROM test harness foundation - makes correctness observable
+
+### Add After Validation (v1.x)
+
+- [ ] PPU mode timing and VRAM/OAM restrictions - needed before rendering correctness
+- [ ] Background rendering - first visible output path
+- [ ] Joypad input - required for interactive games
+- [ ] MBC1/MBC3/MBC5 expansion - needed for wider ROM compatibility
+
+### Future Consideration (v2+)
+
+- [ ] CGB support - defer until DMG path is stable
+- [ ] APU audio output - defer until core timing is stable
+- [ ] Desktop UI polish - defer until emulator core can run target ROMs
+
+## Feature Prioritization Matrix
+
+| Feature | User Value | Implementation Cost | Priority |
+|---------|------------|---------------------|----------|
+| Binary ROM loading | HIGH | LOW | P1 |
+| Cartridge header parsing | HIGH | MEDIUM | P1 |
+| Bus/memory map | HIGH | MEDIUM | P1 |
+| CPU registers and fetch/decode/execute | HIGH | HIGH | P1 |
+| CPU instruction families | HIGH | HIGH | P1 |
+| Timer and interrupts | HIGH | HIGH | P1 |
+| ROM harness | HIGH | MEDIUM | P1 |
+| PPU rendering | MEDIUM | HIGH | P2 |
+| Joypad | MEDIUM | MEDIUM | P2 |
+| APU | MEDIUM | HIGH | P3 |
+| CGB | MEDIUM | HIGH | P3 |
+
+## Competitor Feature Analysis
+
+| Feature | Reference Emulators | Test Suites | Our Approach |
+|---------|---------------------|-------------|--------------|
+| CPU correctness | Mature emulators implement instruction families and flags carefully | blargg CPU tests | Build small, tested instruction groups |
+| Timing correctness | Mature emulators model timer/interrupt quirks explicitly | mooneye acceptance tests | Use internal counter and phase gates |
+| Cartridge support | Mature emulators support many MBCs | mooneye emulator-only MBC tests | Start with simplest cartridge path, expand after bus is stable |
+
+## Sources
+
+- https://gbdev.io/pandocs/Memory_Map.html - cartridge header and memory map expectations
+- https://gbdev.io/pandocs/Interrupts.html - `IME`, `IE`, `IF`, and delayed `ei`
+- https://github.com/Gekkio/mooneye-test-suite - suite structure and pass/fail reporting
+- `docs/hot_to_proceed.md` - local implementation roadmap
+- `.planning/codebase/CONCERNS.md` - current gaps and risks
+
+---
+*Feature research for: Rust DMG Game Boy emulator*
+*Researched: 2026-05-02*

--- a/.planning/research/PITFALLS.md
+++ b/.planning/research/PITFALLS.md
@@ -1,0 +1,184 @@
+# Pitfalls Research
+
+**Domain:** Rust DMG Game Boy emulator
+**Researched:** 2026-05-02
+**Confidence:** HIGH
+
+## Critical Pitfalls
+
+### Pitfall 1: Treating ROMs as Text
+
+**What goes wrong:**
+Real `.gb` files fail to load or are conceptually handled as text instead of bytes.
+
+**Why it happens:**
+The current CLI prototype uses `fs::read_to_string`, which is convenient for text files but wrong for binary cartridges.
+
+**How to avoid:**
+Use `std::fs::read` and pass `Vec<u8>` into a cartridge parser.
+
+**Warning signs:**
+Panics on valid ROMs, lossy conversions, or code that assumes UTF-8.
+
+**Phase to address:**
+Phase 1.
+
+---
+
+### Pitfall 2: Scattering Memory Map Logic
+
+**What goes wrong:**
+CPU code accumulates address ranges and device side effects directly.
+
+**Why it happens:**
+It seems quicker to special-case reads/writes close to instruction code.
+
+**How to avoid:**
+Create a Bus abstraction before broad instruction work.
+
+**Warning signs:**
+Multiple files match on `0xFF00`, `0x8000`, `0xA000`, or cartridge ranges independently.
+
+**Phase to address:**
+Phase 1.
+
+---
+
+### Pitfall 3: Adding Timing Too Late
+
+**What goes wrong:**
+Instructions work in isolation but timer, interrupt, HALT, and PPU tests fail.
+
+**Why it happens:**
+Cycle accounting is deferred until after opcode behavior exists.
+
+**How to avoid:**
+Have instruction execution return elapsed cycles from the first CPU milestone and advance timer/PPU state through that path.
+
+**Warning signs:**
+Instruction functions return only values/state, not timing; tests ignore cycles.
+
+**Phase to address:**
+Phase 2 and Phase 3.
+
+---
+
+### Pitfall 4: Incorrect Timer Model
+
+**What goes wrong:**
+Timer tests fail around DIV writes, TAC changes, overflow reload, and interrupt requests.
+
+**Why it happens:**
+Developers model DIV/TIMA as independent counters instead of using the internal system counter behavior.
+
+**How to avoid:**
+Model a system counter and use selected-bit falling edges for TIMA ticks. Respect one-M-cycle delayed overflow reload.
+
+**Warning signs:**
+Timer code increments TIMA by elapsed time directly with no selected-bit edge logic.
+
+**Phase to address:**
+Phase 3.
+
+---
+
+### Pitfall 5: Test ROMs Exist But Are Not Harnessed
+
+**What goes wrong:**
+The repository has strong validation assets but progress remains manual and subjective.
+
+**Why it happens:**
+Building a harness feels secondary to implementing emulator features.
+
+**How to avoid:**
+Add a minimal automated harness as soon as CPU stepping can run enough instructions to observe pass/fail signals.
+
+**Warning signs:**
+Manual notes say a ROM passes, but `cargo test` cannot reproduce it.
+
+**Phase to address:**
+Phase 4.
+
+---
+
+## Technical Debt Patterns
+
+| Shortcut | Immediate Benefit | Long-term Cost | When Acceptable |
+|----------|-------------------|----------------|-----------------|
+| One large `main.rs` | Fast start | No reusable core, hard tests | Only before Phase 1 begins |
+| Giant opcode match without grouped tests | Quick coverage illusion | Hard to isolate broken flags/cycles | Accept only with per-family tests |
+| Stub all devices as zero | CPU demos may start | Hidden dependency bugs in real ROMs | Accept briefly if tracked by explicit tests |
+| Ignore CGB flags entirely | Simpler DMG scope | Accidental behavior ambiguity | Accept for v1 if documented as DMG-only |
+
+## Integration Gotchas
+
+| Integration | Common Mistake | Correct Approach |
+|-------------|----------------|------------------|
+| Cartridge header | Reading fields without length checks | Validate minimum length before indexing |
+| MBC writes | Treating ROM area as read-only only | Route writes to cartridge mapper state |
+| Interrupt registers | Storing `IME` as memory-mapped state | Model `IME` as CPU-internal, with `IE`/`IF` mapped |
+| Timer registers | Updating TIMA independently | Use system counter edge behavior |
+
+## Performance Traps
+
+| Trap | Symptoms | Prevention | When It Breaks |
+|------|----------|------------|----------------|
+| Over-allocating per instruction | Slow ROM execution | Keep CPU step allocation-free | Once running full frames |
+| String-based debug output in hot loop | Huge slowdown | Gate tracing behind debug/config flags | Any real ROM loop |
+| Premature dynamic dispatch everywhere | Harder optimization/debugging | Use enums/simple structs first | Larger MBC/device set |
+
+## Security Mistakes
+
+| Mistake | Risk | Prevention |
+|---------|------|------------|
+| Unchecked ROM indexing | Panic on malformed input | Bounds-check header and mapper reads |
+| Unsafe Rust for speed before profiling | Memory safety bugs | Stay safe Rust until measured need exists |
+| Trusting path extension as file validity | Invalid files reach parser | Validate bytes and header fields |
+
+## UX Pitfalls
+
+| Pitfall | User Impact | Better Approach |
+|---------|-------------|-----------------|
+| Panic on normal user errors | Confusing CLI failures | Return structured errors at CLI boundary |
+| No pass/fail reporting for tests | Hard to know progress | Make test harness results visible in `cargo test` |
+| UI before core | Pretty shell with no correctness | Make core milestones observable first |
+
+## "Looks Done But Isn't" Checklist
+
+- [ ] **ROM loading:** Often missing binary read and header validation - verify with real `.gb` bytes.
+- [ ] **CPU opcodes:** Often missing correct flags/cycles - verify by instruction family.
+- [ ] **Timer:** Often missing DIV/TAC edge behavior - verify with mooneye timer tests.
+- [ ] **Interrupts:** Often missing delayed `ei` and vector timing - verify with targeted tests.
+- [ ] **PPU mode:** Often missing VRAM/OAM access restrictions - verify before rendering-heavy work.
+
+## Recovery Strategies
+
+| Pitfall | Recovery Cost | Recovery Steps |
+|---------|---------------|----------------|
+| Text ROM loading | LOW | Replace with `fs::read`, add CLI tests |
+| Scattered bus logic | MEDIUM | Extract Bus, move all read/write paths behind it |
+| Timing added late | HIGH | Refactor CPU step signatures and backfill cycle tests |
+| Wrong timer model | HIGH | Rewrite around system counter and mooneye tests |
+| No ROM harness | MEDIUM | Add helper runner, start with a small passing subset |
+
+## Pitfall-to-Phase Mapping
+
+| Pitfall | Prevention Phase | Verification |
+|---------|------------------|--------------|
+| Treating ROMs as text | Phase 1 | Binary load unit/integration test |
+| Scattered memory map logic | Phase 1 | Bus read/write tests for core regions |
+| Adding timing too late | Phase 2 | CPU step returns cycles for every implemented instruction |
+| Incorrect timer model | Phase 3 | Timer register and edge tests |
+| Test ROMs not harnessed | Phase 4 | At least one ROM fixture executable through `cargo test` |
+
+## Sources
+
+- https://doc.rust-lang.org/std/fs/fn.read.html - byte-oriented file reads
+- https://gbdev.io/pandocs/Timer_Obscure_Behaviour.html - timer edge and overflow behavior
+- https://gbdev.io/pandocs/Interrupts.html - interrupt register and `IME` behavior
+- https://github.com/Gekkio/mooneye-test-suite - pass/fail reporting and test suite structure
+- `.planning/codebase/CONCERNS.md` - current repo-specific risks
+
+---
+*Pitfalls research for: Rust DMG Game Boy emulator*
+*Researched: 2026-05-02*

--- a/.planning/research/STACK.md
+++ b/.planning/research/STACK.md
@@ -1,0 +1,89 @@
+# Stack Research
+
+**Domain:** Rust DMG Game Boy emulator
+**Researched:** 2026-05-02
+**Confidence:** HIGH
+
+## Recommended Stack
+
+### Core Technologies
+
+| Technology | Version | Purpose | Why Recommended |
+|------------|---------|---------|-----------------|
+| Rust stable | Current official docs show 1.95.0 | Emulator core and CLI | Existing crate is Rust 2021; Rust gives explicit ownership and bounds-checked data handling for untrusted ROM bytes |
+| Cargo | Bundled with Rust toolchain | Build, test, lint entry point | Existing repo already uses `Cargo.toml` and `Cargo.lock`; keeps the project simple |
+| Rust standard library | Bundled | CLI, filesystem, byte buffers | Enough for Phase 1 cartridge loading and core data structures; avoid dependencies until a real need appears |
+
+### Supporting Libraries
+
+| Library | Version | Purpose | When to Use |
+|---------|---------|---------|-------------|
+| None for Phase 1 | n/a | Keep the emulator core dependency-free | Use for cartridge loading, bus, CPU basics, timer, and initial tests |
+| clap | Defer | Rich CLI parsing | Consider only when CLI commands/options grow past one ROM path |
+| pixels/winit | Defer | Window/display output | Consider after CPU/bus/timer/PPU mode foundations can run meaningful frames |
+| cpal | Defer | Audio output | Consider after APU state is implemented and testable |
+
+### Development Tools
+
+| Tool | Purpose | Notes |
+|------|---------|-------|
+| rustfmt | Formatting | Existing CI already runs `cargo fmt --all` |
+| Clippy | Linting | Existing CI runs `cargo clippy`; keep new code clippy-clean |
+| Cargo tests | Unit and integration tests | Add unit tests early; add ROM integration harness once execution loop exists |
+| blargg and mooneye ROMs | Hardware behavior validation | Already checked into `roms/`; wire them into tests in later phases |
+
+## Installation
+
+```bash
+# Existing stack is already dependency-free.
+cargo build
+cargo test
+cargo clippy
+```
+
+No new crates are recommended for the first milestone.
+
+## Alternatives Considered
+
+| Recommended | Alternative | When to Use Alternative |
+|-------------|-------------|-------------------------|
+| Standard library CLI parsing | clap | Use clap when there are multiple commands, flags, config files, or richer error messages |
+| `fs::read` for ROM bytes | `fs::read_to_string` | Never for ROMs; ROMs are binary, not UTF-8 text |
+| Dependency-free core | Framework-heavy emulator shell | Add host UI/audio dependencies only after core correctness has something to drive |
+
+## What NOT to Use
+
+| Avoid | Why | Use Instead |
+|-------|-----|-------------|
+| Text file reads for ROMs | `.gb` and `.gbc` are binary files; text reads can fail or misrepresent data | `std::fs::read`, which returns `Vec<u8>` |
+| CGB-first architecture | Color-specific behavior multiplies memory, timing, and rendering variance | DMG-first modules with explicit extension points |
+| UI/audio dependencies in Phase 1 | They distract from core correctness and make tests harder | Core crate modules plus Cargo tests |
+| Unsafe indexing as a shortcut | ROM parsing is untrusted binary input | Bounds-checked slices and explicit parse errors |
+
+## Stack Patterns by Variant
+
+**If building the first milestone:**
+- Use only Rust std, Cargo tests, and checked-in ROM fixtures.
+- Because the main risk is correctness, not host integration.
+
+**If adding a desktop shell later:**
+- Keep the emulator core reusable and add host display/audio/input in separate modules.
+- Because UI refresh and audio callbacks should not own hardware rules.
+
+## Version Compatibility
+
+| Package A | Compatible With | Notes |
+|-----------|-----------------|-------|
+| Rust stable | Cargo, rustfmt, Clippy | No pinned version currently; add `rust-toolchain.toml` if reproducibility becomes important |
+| Rust std `fs::read` | Rust 1.26.0+ | Official docs show it returns `Result<Vec<u8>>`, which matches ROM loading needs |
+
+## Sources
+
+- https://doc.rust-lang.org/std/fs/fn.read.html - verified byte-oriented file loading API
+- https://gbdev.io/pandocs/Memory_Map.html - verified cartridge memory ranges and header location
+- https://github.com/gbdev/pandocs - verified Pan Docs as a maintained public Game Boy technical reference
+- `.planning/codebase/STACK.md` - verified current repo stack
+
+---
+*Stack research for: Rust DMG Game Boy emulator*
+*Researched: 2026-05-02*

--- a/.planning/research/SUMMARY.md
+++ b/.planning/research/SUMMARY.md
@@ -1,0 +1,151 @@
+# Project Research Summary
+
+**Project:** GameGirl
+**Domain:** Rust DMG Game Boy emulator
+**Researched:** 2026-05-02
+**Confidence:** HIGH
+
+## Executive Summary
+
+GameGirl is best treated as a correctness-first emulator core project, not a UI project. The current repo is a Rust CLI scaffold with strong supporting materials: local Game Boy research, an implementation roadmap, and blargg/mooneye ROM fixtures. The first milestone should convert that scaffold into a byte-oriented cartridge loader, a Bus-centered hardware model, a CPU stepping foundation, and early validation tests.
+
+The recommended stack is deliberately small: Rust stable, Cargo, rustfmt, Clippy, and standard library APIs for the core. The highest leverage architectural choice is to separate the CLI from a reusable emulator core, then route all CPU-visible memory through a Bus. The highest risk is timing correctness, especially timer/interrupt behavior; the roadmap should introduce cycle accounting early rather than trying to bolt it on after opcodes appear.
+
+## Key Findings
+
+### Recommended Stack
+
+Use the existing Rust 2021 Cargo crate and keep Phase 1 dependency-free. The Rust standard library already provides byte-oriented ROM loading with `std::fs::read`, and Cargo gives enough testing/linting structure for the first emulator core phases.
+
+**Core technologies:**
+- Rust stable: emulator core and CLI - matches existing crate and supports safe binary parsing
+- Cargo: build/test/lint - already present through `Cargo.toml` and `Cargo.lock`
+- Rust std: filesystem and data structures - enough for cartridge, bus, CPU, and timer foundations
+
+### Expected Features
+
+**Must have (table stakes):**
+- Binary ROM loading - users expect real `.gb` input to work
+- Cartridge header parsing - required to identify ROM/mapper metadata
+- DMG Bus/memory map - required for CPU-visible hardware behavior
+- CPU register and instruction stepping - the core emulator loop
+- Timer and interrupt foundations - needed for meaningful compatibility
+- Test harness foundation - uses checked-in ROM suites for validation
+
+**Should have (competitive):**
+- Test-ROM-driven milestones - makes progress hard to fake
+- Clean hardware module boundaries - makes timing fixes safer
+- DMG-first scope discipline - prevents CGB complexity from derailing v1
+
+**Defer (v2+):**
+- CGB support - not essential until DMG is stable
+- APU/audio output - high complexity and timing-sensitive
+- Polished desktop UI - valuable later, not before core execution works
+
+### Architecture Approach
+
+Use a thin host boundary and reusable emulator core. `src/main.rs` should parse paths, load bytes, and report errors; `src/lib.rs` and focused modules should own cartridge, bus, CPU, timer, interrupts, PPU, joypad, and tests. CPU execution should go through Bus for all memory access and return elapsed cycles so timer/PPU/interrupt state can advance consistently.
+
+**Major components:**
+1. Cartridge - owns ROM bytes, parses header, and later handles MBC behavior
+2. Bus - routes 16-bit reads/writes to cartridge, RAM, and I/O devices
+3. CPU - owns registers, flags, instruction decode/execute, stack, and cycle results
+4. Timer/Interrupts - model memory-mapped registers and CPU interrupt behavior
+5. Test Harness - runs unit and ROM-level checks through Cargo
+
+### Critical Pitfalls
+
+1. **Treating ROMs as text** - replace `read_to_string` with `fs::read`
+2. **Scattering memory map logic** - create Bus before broad opcode work
+3. **Adding timing too late** - return cycles from CPU stepping from the start
+4. **Incorrect timer model** - use internal system counter and edge behavior
+5. **Test ROMs not harnessed** - wire fixtures into automated tests once execution can report pass/fail
+
+## Implications for Roadmap
+
+Based on research, suggested phase structure:
+
+### Phase 1: Cartridge and Bus Foundation
+**Rationale:** Real binary input and a memory map must exist before CPU work can be meaningful.
+**Delivers:** Byte ROM loading, cartridge header parsing, basic memory regions, Bus read/write API.
+**Addresses:** ROM loading, cartridge parsing, memory map.
+**Avoids:** Treating ROMs as text; scattered memory map logic.
+
+### Phase 2: CPU Core Foundation
+**Rationale:** CPU state and stepping are the next dependency for all ROM execution.
+**Delivers:** Registers, flags, fetch/decode/execute loop, initial instruction families, cycle-returning step.
+**Uses:** Bus API from Phase 1.
+**Implements:** CPU component.
+
+### Phase 3: Timer and Interrupt Foundations
+**Rationale:** Many tests and games depend on timer/interrupt timing before graphics are useful.
+**Delivers:** DIV/TIMA/TMA/TAC, IE/IF/IME, delayed `ei`, interrupt dispatch basics.
+**Uses:** CPU cycles and Bus I/O registers.
+**Implements:** Timer and interrupt components.
+
+### Phase 4: Test ROM Harness
+**Rationale:** The repo already has ROM fixtures; automation turns them into milestone gates.
+**Delivers:** Cargo-based harness for a small initial blargg/mooneye subset with timeouts and pass/fail detection.
+**Uses:** CPU, bus, timer, interrupt foundations.
+
+### Phase 5: PPU Mode Skeleton and Access Rules
+**Rationale:** PPU mode timing and VRAM/OAM restrictions should exist before pixel rendering.
+**Delivers:** PPU modes, LY/dot stepping, VRAM/OAM access restrictions, VBlank/LCD interrupt hooks.
+**Uses:** Bus and cycle advancement.
+
+### Phase Ordering Rationale
+
+- Binary ROM loading and Bus come first because every later subsystem depends on address routing.
+- CPU comes before timer/interrupt harnessing because tests need execution.
+- Timer/interrupts come before PPU rendering because timing correctness affects CPU tests and system behavior.
+- ROM harness appears before visual output so compatibility remains measurable.
+- PPU mode rules precede rendering to avoid building a display path on incorrect access timing.
+
+### Research Flags
+
+Phases likely needing deeper research during planning:
+- **Phase 2:** CPU instruction flags and cycle counts need careful source checks.
+- **Phase 3:** Timer obscure behavior and interrupt timing need precise test-backed planning.
+- **Phase 5:** PPU mode timing and VRAM/OAM restrictions need deeper source review.
+
+Phases with standard patterns:
+- **Phase 1:** Rust binary file loading, header parsing, and Bus scaffolding are straightforward.
+- **Phase 4:** Harness shape is standard once pass/fail signal is chosen.
+
+## Confidence Assessment
+
+| Area | Confidence | Notes |
+|------|------------|-------|
+| Stack | HIGH | Existing Rust crate and official Rust docs support a minimal dependency-free core |
+| Features | HIGH | Local docs, Pan Docs, and emulator test suites align on core needs |
+| Architecture | HIGH | Bus-centered module split follows the hardware memory map and local docs |
+| Pitfalls | HIGH | Current code already exhibits the binary/text loading pitfall; timer/interrupt pitfalls are documented |
+
+**Overall confidence:** HIGH
+
+### Gaps to Address
+
+- CPU opcode implementation details: resolve during Phase 2 planning with instruction tables and targeted tests.
+- ROM pass/fail protocol: choose exact detection strategy during Phase 4 planning.
+- PPU rendering detail: defer until mode/access rules are in place.
+- MBC scope: decide first mapper during cartridge planning; avoid broad mapper work too early.
+
+## Sources
+
+### Primary (HIGH confidence)
+
+- https://doc.rust-lang.org/std/fs/fn.read.html - Rust byte file read API
+- https://gbdev.io/pandocs/Memory_Map.html - memory map and cartridge header
+- https://gbdev.io/pandocs/Timer_Obscure_Behaviour.html - timer model and overflow behavior
+- https://gbdev.io/pandocs/Interrupts.html - interrupt registers and `IME`
+- https://github.com/Gekkio/mooneye-test-suite - test suite structure and pass/fail reporting
+
+### Secondary (MEDIUM confidence)
+
+- `docs/hot_to_proceed.md` - local implementation roadmap
+- `docs/gameboy_architecture_summary.md` - local DMG implementation summary
+- `.planning/codebase/*.md` - current brownfield codebase map
+
+---
+*Research completed: 2026-05-02*
+*Ready for roadmap: yes*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,200 @@
+<!-- GSD:project-start source:PROJECT.md -->
+## Project
+
+**GameGirl**
+
+GameGirl is a Rust Game Boy emulator project. The repository currently contains a minimal CLI scaffold, implementation notes, Game Boy hardware research, and a substantial local ROM corpus for future validation.
+
+The immediate product direction is a DMG-first emulator core that can load real `.gb` ROM bytes, model the CPU/bus/devices accurately enough to run test ROMs, and grow toward rendering, input, cartridges, and audio in deliberate phases.
+
+**Core Value:** GameGirl must execute DMG Game Boy ROMs accurately enough that behavior is driven by hardware rules and verified by known test ROMs, not by ad hoc demo success.
+
+### Constraints
+
+- **Tech stack**: Rust 2021 with Cargo — match the existing crate and avoid adding dependencies unless they remove real implementation risk.
+- **Compatibility**: DMG-first — keep Color Game Boy behavior out of the initial critical path.
+- **Correctness**: Use test ROMs as a decision aid when documentation and intuition disagree.
+- **Architecture**: Keep CPU, bus, cartridge, timer, PPU, joypad, and eventual APU responsibilities separated so hardware timing rules can be tested in isolation.
+- **Input data**: ROMs are untrusted binary files — cartridge parsing must be bounds-checked and avoid unsafe Rust by default.
+- **Validation**: Prefer small unit tests for pure CPU/device behavior and ROM-driven integration tests for compatibility.
+<!-- GSD:project-end -->
+
+<!-- GSD:stack-start source:codebase/STACK.md -->
+## Technology Stack
+
+## Languages
+- Rust 2021 edition - all executable application code currently lives in `src/main.rs`.
+- Markdown - project documentation in `README.md`, `docs/hot_to_proceed.md`, `docs/gameboy_architecture_summary.md`, and ROM notes.
+- Game Boy assembly - sample and upstream test ROM sources under `roms/**/source/` and `roms/hello-world/hello-world.asm`.
+- YAML - GitHub Actions and repository automation under `.github/`.
+## Runtime
+- Native Rust binary built with Cargo.
+- No explicit minimum Rust toolchain is pinned in `Cargo.toml`, `rust-toolchain.toml`, or `.github/`.
+- CI installs the stable Rust toolchain in `.github/workflows/rust-clippy.yml`.
+- Cargo - package metadata in `Cargo.toml`.
+- Lockfile: `Cargo.lock` is present.
+## Frameworks
+- None. The current crate uses only Rust standard library APIs.
+- Cargo test harness - invoked by `.github/workflows/rust.yml`.
+- External ROM fixtures - `roms/blargg-gb-tests/`, `roms/mooneye/`, and `roms/hello-world/` provide future emulator validation assets, but no automated harness consumes them yet.
+- Cargo - build, format, lint, and test commands.
+- rustfmt - run in `.github/workflows/rust.yml` through `cargo fmt --all`.
+- Clippy - run in `.github/workflows/rust.yml` and SARIF-producing `.github/workflows/rust-clippy.yml`.
+## Key Dependencies
+- Rust standard library - `std::env` for CLI argument collection and `std::fs` for file reading in `src/main.rs`.
+- GitHub Actions - CI, labeling, first-interaction greeting, dependency review, auto-assignment, and clippy SARIF upload.
+- No crates are listed in `[dependencies]` in `Cargo.toml`.
+## Configuration
+- No application environment variables are required.
+- Runtime configuration is currently only the first CLI argument: a path ending in `.gb` or `.gbc`.
+- `Cargo.toml` - Rust package metadata.
+- `Cargo.lock` - dependency lockfile.
+- `.editorconfig` - editor formatting baseline.
+- `.github/workflows/*.yml` - CI automation.
+## Platform Requirements
+- Any platform with a compatible Rust toolchain and Cargo.
+- No external database, service, or local daemon is required.
+- Not defined yet. The package metadata describes "A GameBoy emulator written in Rust", but the current executable is only a prototype CLI.
+<!-- GSD:stack-end -->
+
+<!-- GSD:conventions-start source:CONVENTIONS.md -->
+## Conventions
+
+## Naming Patterns
+- Rust files should use snake_case, matching standard Rust conventions.
+- Current source file is `src/main.rs`.
+- Future emulator modules should use focused names such as `cpu.rs`, `bus.rs`, `cartridge.rs`, `timer.rs`, and `ppu.rs`.
+- Rust functions use snake_case.
+- Current executable uses a single `main()` function.
+- Rust local variables use snake_case, as seen with `args`, `file_path`, and `contents` in `src/main.rs`.
+- Constants are not present yet; use UPPER_SNAKE_CASE for future compile-time constants.
+- No project types are defined yet.
+- Future structs/enums should use PascalCase, matching Rust convention.
+## Code Style
+- rustfmt is the expected formatter.
+- CI runs `cargo fmt --all` in `.github/workflows/rust.yml`.
+- Indentation and formatting should follow Rust defaults.
+- Clippy is expected.
+- CI runs `cargo clippy` in `.github/workflows/rust.yml`.
+- A separate clippy SARIF workflow exists at `.github/workflows/rust-clippy.yml`.
+## Import Organization
+- Current code groups `std::env` and `std::fs` together at the top of `src/main.rs`.
+- Keep imports simple and explicit.
+- None.
+## Error Handling
+- Current code uses early return for missing arguments and invalid extensions.
+- Current code panics on file read failure through `expect`.
+- As emulator code grows, prefer returning `Result` from parsing/loading helpers so CLI boundaries can format errors without panics.
+- None defined yet.
+- Future cartridge loading should distinguish invalid path, unsupported extension, unreadable file, invalid header, and unsupported MBC.
+## Logging
+- `println!` and `eprintln!` only.
+- Use `eprintln!` for usage and errors.
+- Keep emulator core free of console output; return structured results/errors to the boundary instead.
+## Comments
+- Explain hardware quirks, timing assumptions, and spec/test-ROM discrepancies.
+- Good candidates include DAA flag behavior, timer falling-edge behavior, delayed `ei`, HALT behavior, and PPU access restrictions.
+- Avoid comments that merely restate straightforward Rust statements.
+- Not used yet.
+- Add Rustdoc for public emulator structs, especially if a `lib.rs` is introduced.
+- No project TODO pattern is established.
+- Prefer tracking planned work in `.planning/` requirements and phase plans once initialization is complete.
+## Function Design
+- `main()` is currently short.
+- Future instruction and device logic should be split into small helpers because emulator correctness depends on many edge cases.
+- Prefer typed structs over long parameter lists for hardware state.
+- Keep CPU/device state ownership explicit.
+- Prefer `Result<T, E>` for fallible loading/parsing.
+- Avoid hidden panics in emulator core code.
+## Module Design
+- No module export pattern exists yet.
+- If the project grows past a single binary, introduce `src/lib.rs` for reusable emulator core and keep `src/main.rs` as a CLI shell.
+- Keep CPU instruction execution independent from cartridge file I/O.
+- Route memory-mapped reads/writes through a Bus abstraction.
+- Keep rendering/audio backends separate from timing-accurate PPU/APU state.
+<!-- GSD:conventions-end -->
+
+<!-- GSD:architecture-start source:ARCHITECTURE.md -->
+## Architecture
+
+## Pattern Overview
+- Single binary crate.
+- Single source file: `src/main.rs`.
+- No emulator domain modules have been implemented yet.
+- Documentation already describes the intended emulator architecture and implementation roadmap.
+- ROM fixtures are present for later validation, but they are not wired into automated tests.
+## Layers
+- Purpose: Accept command-line input and report usage/errors to the user.
+- Contains: argument collection, extension validation, console output.
+- Location: `src/main.rs`.
+- Depends on: Rust standard library only.
+- Used by: direct binary execution through Cargo or compiled executable.
+- Purpose: Load the supplied ROM path.
+- Contains: a call to `fs::read_to_string`.
+- Location: `src/main.rs`.
+- Depends on: local filesystem.
+- Used by: CLI boundary after extension validation.
+- Purpose: Eventually model Game Boy hardware behavior.
+- Contains: not implemented yet.
+- Intended components from `docs/hot_to_proceed.md` and `docs/gameboy_architecture_summary.md`:
+## Data Flow
+- Current application state is local to `main`.
+- Planned emulator state should be explicit structs for CPU registers, bus, memory, cartridge, timer, PPU, joypad, and later APU.
+- No persistence is implemented yet.
+## Key Abstractions
+- Purpose: Minimal command runner.
+- Example: `src/main.rs`.
+- Pattern: single `main()` function.
+- Purpose: Centralize 16-bit address / 8-bit data reads and writes across CPU-visible devices.
+- Examples: none implemented.
+- Pattern: should become the boundary between CPU and devices.
+- Purpose: Implement LR35902 registers, instruction decode, execution, flags, and timing.
+- Examples: none implemented.
+- Pattern: likely `Cpu` struct plus opcode execution helpers.
+- Purpose: Hold ROM bytes, parse header metadata, and provide MBC behavior.
+- Examples: none implemented.
+- Pattern: trait or enum-backed mapper implementations may fit future MBC0/MBC1/MBC3/MBC5 support.
+## Entry Points
+- Location: `src/main.rs`.
+- Triggers: user runs the binary through Cargo or direct executable invocation.
+- Responsibilities: validate arguments, read supplied file, print result.
+## Error Handling
+- `eprintln!` for missing-argument usage.
+- `println!` for invalid extension.
+- `expect("Something went wrong reading the file")` for read failures.
+## Cross-Cutting Concerns
+- Console output only.
+- No structured logging or log levels.
+- Simple filename suffix check for `.gb` and `.gbc`.
+- No binary header validation yet.
+- No source-level tests currently exist.
+- Future emulator behavior should be validated against checked-in blargg and mooneye ROMs.
+<!-- GSD:architecture-end -->
+
+<!-- GSD:skills-start source:skills/ -->
+## Project Skills
+
+No project skills found. Add skills to any of: `.claude/skills/`, `.agents/skills/`, `.cursor/skills/`, `.github/skills/`, or `.codex/skills/` with a `SKILL.md` index file.
+<!-- GSD:skills-end -->
+
+<!-- GSD:workflow-start source:GSD defaults -->
+## GSD Workflow Enforcement
+
+Before using Edit, Write, or other file-changing tools, start work through a GSD command so planning artifacts and execution context stay in sync.
+
+Use these entry points:
+- `/gsd-quick` for small fixes, doc updates, and ad-hoc tasks
+- `/gsd-debug` for investigation and bug fixing
+- `/gsd-execute-phase` for planned phase work
+
+Do not make direct repo edits outside a GSD workflow unless the user explicitly asks to bypass it.
+<!-- GSD:workflow-end -->
+
+
+
+<!-- GSD:profile-start -->
+## Developer Profile
+
+> Profile not yet configured. Run `/gsd-profile-user` to generate your developer profile.
+> This section is managed by `generate-claude-profile` -- do not edit manually.
+<!-- GSD:profile-end -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,13 +23,13 @@ The immediate product direction is a DMG-first emulator core that can load real 
 ## Technology Stack
 
 ## Languages
-- Rust 2021 edition - all executable application code currently lives in `src/main.rs`.
+- Rust 2021 edition - the CLI entry point lives in `src/main.rs`, with reusable emulator modules exported through `src/lib.rs`.
 - Markdown - project documentation in `README.md`, `docs/hot_to_proceed.md`, `docs/gameboy_architecture_summary.md`, and ROM notes.
 - Game Boy assembly - sample and upstream test ROM sources under `roms/**/source/` and `roms/hello-world/hello-world.asm`.
 - YAML - GitHub Actions and repository automation under `.github/`.
 ## Runtime
 - Native Rust binary built with Cargo.
-- No explicit minimum Rust toolchain is pinned in `Cargo.toml`, `rust-toolchain.toml`, or `.github/`.
+- No explicit minimum Rust toolchain is pinned in Cargo metadata or repository toolchain configuration.
 - CI installs the stable Rust toolchain in `.github/workflows/rust-clippy.yml`.
 - Cargo - package metadata in `Cargo.toml`.
 - Lockfile: `Cargo.lock` is present.
@@ -41,7 +41,7 @@ The immediate product direction is a DMG-first emulator core that can load real 
 - rustfmt - run in `.github/workflows/rust.yml` through `cargo fmt --all`.
 - Clippy - run in `.github/workflows/rust.yml` and SARIF-producing `.github/workflows/rust-clippy.yml`.
 ## Key Dependencies
-- Rust standard library - `std::env` for CLI argument collection and `std::fs` for file reading in `src/main.rs`.
+- Rust standard library - `std::env`, `std::path`, and `std::process` in `src/main.rs`, plus `std::fs` for ROM file reads in `src/cartridge.rs`.
 - GitHub Actions - CI, labeling, first-interaction greeting, dependency review, auto-assignment, and clippy SARIF upload.
 - No crates are listed in `[dependencies]` in `Cargo.toml`.
 ## Configuration
@@ -50,11 +50,11 @@ The immediate product direction is a DMG-first emulator core that can load real 
 - `Cargo.toml` - Rust package metadata.
 - `Cargo.lock` - dependency lockfile.
 - `.editorconfig` - editor formatting baseline.
-- `.github/workflows/*.yml` - CI automation.
+- GitHub workflow YAML files under `.github/workflows/` - CI automation.
 ## Platform Requirements
 - Any platform with a compatible Rust toolchain and Cargo.
 - No external database, service, or local daemon is required.
-- Not defined yet. The package metadata describes "A GameBoy emulator written in Rust", but the current executable is only a prototype CLI.
+- The package metadata describes "A GameBoy emulator written in Rust"; the current executable is a CLI that validates and loads ROM bytes.
 <!-- GSD:stack-end -->
 
 <!-- GSD:conventions-start source:CONVENTIONS.md -->
@@ -62,14 +62,14 @@ The immediate product direction is a DMG-first emulator core that can load real 
 
 ## Naming Patterns
 - Rust files should use snake_case, matching standard Rust conventions.
-- Current source file is `src/main.rs`.
-- Future emulator modules should use focused names such as `cpu.rs`, `bus.rs`, `cartridge.rs`, `timer.rs`, and `ppu.rs`.
+- Current Rust source files are `src/main.rs`, `src/lib.rs`, `src/cartridge.rs`, and `src/bus.rs`.
+- Emulator modules should use focused names such as cpu, timer, and ppu as new subsystems are added.
 - Rust functions use snake_case.
 - Current executable uses a single `main()` function.
-- Rust local variables use snake_case, as seen with `args`, `file_path`, and `contents` in `src/main.rs`.
-- Constants are not present yet; use UPPER_SNAKE_CASE for future compile-time constants.
-- No project types are defined yet.
-- Future structs/enums should use PascalCase, matching Rust convention.
+- Rust local variables use snake_case, as seen with `args`, `program`, and `file_path` in `src/main.rs`.
+- Compile-time constants use UPPER_SNAKE_CASE, as seen in cartridge header offsets and Bus memory sizes.
+- Public project types include `Cartridge`, `CartridgeHeader`, `CartridgeType`, `CartridgeError`, and `Bus`.
+- Structs and enums should use PascalCase, matching Rust convention.
 ## Code Style
 - rustfmt is the expected formatter.
 - CI runs `cargo fmt --all` in `.github/workflows/rust.yml`.
@@ -78,15 +78,14 @@ The immediate product direction is a DMG-first emulator core that can load real 
 - CI runs `cargo clippy` in `.github/workflows/rust.yml`.
 - A separate clippy SARIF workflow exists at `.github/workflows/rust-clippy.yml`.
 ## Import Organization
-- Current code groups `std::env` and `std::fs` together at the top of `src/main.rs`.
+- Current code keeps imports narrow and module-local, such as CLI imports in `src/main.rs` and file/path imports in `src/cartridge.rs`.
 - Keep imports simple and explicit.
 - None.
 ## Error Handling
 - Current code uses early return for missing arguments and invalid extensions.
-- Current code panics on file read failure through `expect`.
-- As emulator code grows, prefer returning `Result` from parsing/loading helpers so CLI boundaries can format errors without panics.
-- None defined yet.
-- Future cartridge loading should distinguish invalid path, unsupported extension, unreadable file, invalid header, and unsupported MBC.
+- Cartridge file loading returns `Result` values and the CLI formats errors without panicking.
+- Continue returning `Result` from parsing/loading helpers so CLI boundaries can format errors without panics.
+- Current cartridge loading distinguishes unsupported extension, unreadable file, too-short header, unsupported cartridge type, unsupported ROM size code, and unsupported RAM size code.
 ## Logging
 - `println!` and `eprintln!` only.
 - Use `eprintln!` for usage and errors.
@@ -96,7 +95,7 @@ The immediate product direction is a DMG-first emulator core that can load real 
 - Good candidates include DAA flag behavior, timer falling-edge behavior, delayed `ei`, HALT behavior, and PPU access restrictions.
 - Avoid comments that merely restate straightforward Rust statements.
 - Not used yet.
-- Add Rustdoc for public emulator structs, especially if a `lib.rs` is introduced.
+- Add Rustdoc for public emulator structs as the library API stabilizes.
 - No project TODO pattern is established.
 - Prefer tracking planned work in `.planning/` requirements and phase plans once initialization is complete.
 ## Function Design
@@ -107,8 +106,8 @@ The immediate product direction is a DMG-first emulator core that can load real 
 - Prefer `Result<T, E>` for fallible loading/parsing.
 - Avoid hidden panics in emulator core code.
 ## Module Design
-- No module export pattern exists yet.
-- If the project grows past a single binary, introduce `src/lib.rs` for reusable emulator core and keep `src/main.rs` as a CLI shell.
+- `src/lib.rs` exports reusable emulator core modules, currently `bus` and `cartridge`.
+- Keep `src/main.rs` as a CLI shell around reusable emulator core modules.
 - Keep CPU instruction execution independent from cartridge file I/O.
 - Route memory-mapped reads/writes through a Bus abstraction.
 - Keep rendering/audio backends separate from timing-accurate PPU/APU state.
@@ -118,24 +117,24 @@ The immediate product direction is a DMG-first emulator core that can load real 
 ## Architecture
 
 ## Pattern Overview
-- Single binary crate.
-- Single source file: `src/main.rs`.
-- No emulator domain modules have been implemented yet.
+- Cargo package with both a CLI binary and reusable library modules.
+- Source is split across `src/main.rs`, `src/lib.rs`, `src/cartridge.rs`, and `src/bus.rs`.
+- Cartridge loading/header parsing and Bus address routing modules are implemented.
 - Documentation already describes the intended emulator architecture and implementation roadmap.
 - ROM fixtures are present for later validation, but they are not wired into automated tests.
 ## Layers
-- Purpose: Accept command-line input and report usage/errors to the user.
-- Contains: argument collection, extension validation, console output.
+- Purpose: Accept command-line input, validate ROM paths, delegate ROM loading, and report usage/errors to the user.
+- Contains: argument collection, extension validation, cartridge loading delegation, exit-code handling, and console output.
 - Location: `src/main.rs`.
 - Depends on: Rust standard library only.
 - Used by: direct binary execution through Cargo or compiled executable.
-- Purpose: Load the supplied ROM path.
-- Contains: a call to `fs::read_to_string`.
-- Location: `src/main.rs`.
-- Depends on: local filesystem.
-- Used by: CLI boundary after extension validation.
-- Purpose: Eventually model Game Boy hardware behavior.
-- Contains: not implemented yet.
+- Purpose: Load and validate the supplied ROM path.
+- Contains: byte-oriented file reads, header parsing, ROM-only cartridge construction, and cartridge error types.
+- Location: `src/cartridge.rs`.
+- Depends on: local filesystem for file loading and Rust standard library parsing helpers.
+- Used by: CLI boundary and Bus construction.
+- Purpose: Model Game Boy hardware behavior behind reusable core modules.
+- Contains: cartridge metadata/loading and Bus address routing today; CPU, timer, PPU, joypad, and APU are future subsystems.
 - Intended components from `docs/hot_to_proceed.md` and `docs/gameboy_architecture_summary.md`:
 ## Data Flow
 - Current application state is local to `main`.
@@ -146,35 +145,35 @@ The immediate product direction is a DMG-first emulator core that can load real 
 - Example: `src/main.rs`.
 - Pattern: single `main()` function.
 - Purpose: Centralize 16-bit address / 8-bit data reads and writes across CPU-visible devices.
-- Examples: none implemented.
-- Pattern: should become the boundary between CPU and devices.
+- Examples: `Bus` in `src/bus.rs`.
+- Pattern: boundary between CPU-visible memory access and devices.
 - Purpose: Implement LR35902 registers, instruction decode, execution, flags, and timing.
 - Examples: none implemented.
 - Pattern: likely `Cpu` struct plus opcode execution helpers.
 - Purpose: Hold ROM bytes, parse header metadata, and provide MBC behavior.
-- Examples: none implemented.
-- Pattern: trait or enum-backed mapper implementations may fit future MBC0/MBC1/MBC3/MBC5 support.
+- Examples: `Cartridge`, `CartridgeHeader`, `CartridgeType`, and `CartridgeError` in `src/cartridge.rs`.
+- Pattern: enum-backed cartridge type handling currently accepts ROM-only cartridges and explicitly rejects unsupported cartridge type codes.
 ## Entry Points
 - Location: `src/main.rs`.
 - Triggers: user runs the binary through Cargo or direct executable invocation.
-- Responsibilities: validate arguments, read supplied file, print result.
+- Responsibilities: validate arguments, load supplied ROM bytes through the cartridge module, print result, and return success/failure exit codes.
 ## Error Handling
 - `eprintln!` for missing-argument usage.
-- `println!` for invalid extension.
-- `expect("Something went wrong reading the file")` for read failures.
+- `eprintln!` for invalid extension and cartridge loading errors.
+- Structured cartridge errors for read failures, short ROMs, unsupported type codes, and unsupported size codes.
 ## Cross-Cutting Concerns
 - Console output only.
 - No structured logging or log levels.
-- Simple filename suffix check for `.gb` and `.gbc`.
-- No binary header validation yet.
-- No source-level tests currently exist.
+- Case-insensitive extension check for `.gb` and `.gbc`.
+- Binary cartridge header validation is implemented in `src/cartridge.rs`.
+- Source-level unit tests and CLI integration tests are present.
 - Future emulator behavior should be validated against checked-in blargg and mooneye ROMs.
 <!-- GSD:architecture-end -->
 
 <!-- GSD:skills-start source:skills/ -->
 ## Project Skills
 
-No project skills found. Add skills to any of: `.claude/skills/`, `.agents/skills/`, `.cursor/skills/`, `.github/skills/`, or `.codex/skills/` with a `SKILL.md` index file.
+No project skills found. Add skills to any of: `.claude/skills/`, `.agents/skills/`, `.cursor/skills/`, `.github/skills/`, or `.codex/skills/` with a skill index file.
 <!-- GSD:skills-end -->
 
 <!-- GSD:workflow-start source:GSD defaults -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+<!-- generated-by: gsd-doc-writer -->
+# Contributing
+
+Thank you for helping improve GameGirl. The project is early, so small, well-tested changes are easier to review than broad subsystem rewrites.
+
+## Development Setup
+
+See `docs/GETTING-STARTED.md` for prerequisites and first-run instructions. See `docs/DEVELOPMENT.md` for local development commands, style expectations, and pull-request preparation.
+
+## Coding Standards
+
+- Use Rust 2021 and Cargo.
+- Format Rust code with `cargo fmt --all`.
+- Run `cargo clippy --all-targets -- -D warnings` before opening a pull request.
+- Keep reusable emulator logic in library modules under `src/`; keep command-line argument handling in `src/main.rs`.
+- Add tests for new emulator behavior. Prefer unit tests near pure module logic and integration tests under `tests/` for binary behavior.
+
+## PR Guidelines
+
+- Keep the pull request focused on one behavior, subsystem, or documentation topic.
+- Explain what changed and why.
+- List the commands you ran, especially `cargo test`, `cargo fmt --all -- --check`, and `cargo clippy --all-targets -- -D warnings`.
+- Include new or updated tests when behavior changes.
+- Avoid adding third-party dependencies unless they clearly reduce risk or complexity.
+- For emulator behavior, note any ROM fixtures or hardware references used to validate the change.
+
+## Issue Reporting
+
+Use GitHub Issues for bugs and feature requests.
+
+For bugs, include:
+
+- Steps to reproduce.
+- Expected behavior.
+- Actual behavior.
+- ROM path or fixture used, if applicable.
+- Output from the CLI or test command.
+- Your Rust toolchain version.
+
+For feature requests, include:
+
+- The emulator subsystem involved.
+- The user-visible behavior or compatibility goal.
+- Any known test ROMs, references, or existing implementations that clarify the expected behavior.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,80 @@
+<!-- generated-by: gsd-doc-writer -->
+# Architecture
+
+GameGirl is a Rust Game Boy emulator foundation. The current executable accepts a `.gb` or `.gbc` path, validates and loads ROM bytes through the cartridge module, and exposes reusable core modules for cartridge metadata and DMG-style memory-bus access.
+
+## System Overview
+
+The system is organized as a small Rust binary plus a reusable library crate. The binary in `src/main.rs` owns command-line argument handling and user-facing errors. Emulator-domain behavior lives behind `src/lib.rs`, which exports `cartridge` and `bus` modules. ROM files are the primary input today; the observable output is either a successful byte-count message or a clear loading/parsing error.
+
+## Component Diagram
+
+```mermaid
+graph TD
+    CLI["src/main.rs"]
+    Library["src/lib.rs"]
+    Cartridge["src/cartridge.rs"]
+    Bus["src/bus.rs"]
+    RomFile["ROM file (.gb/.gbc)"]
+
+    CLI --> Cartridge
+    Library --> Cartridge
+    Library --> Bus
+    Bus --> Cartridge
+    RomFile --> CLI
+```
+
+## Data Flow
+
+1. `src/main.rs` reads the first command-line argument and checks that the path extension is `.gb` or `.gbc`.
+2. The CLI calls `game_girl::cartridge::load_rom_file`, which reads bytes with `std::fs::read`.
+3. `Cartridge::from_bytes` parses the cartridge header, validates supported ROM/RAM size codes, and rejects unsupported cartridge types.
+4. `Bus::new` accepts a `Cartridge` and owns the CPU-visible memory backing used by the currently implemented ranges: cartridge ROM, WRAM, OAM, I/O registers, HRAM, and interrupt enable.
+5. Future CPU code should call `Bus::read8` and `Bus::write8` instead of reading cartridge or RAM storage directly.
+
+## Key Abstractions
+
+| Abstraction | Location | Role |
+|-------------|----------|------|
+| `Cartridge` | `src/cartridge.rs` | Owns ROM bytes and exposes ROM-only cartridge reads and writes. |
+| `CartridgeHeader` | `src/cartridge.rs` | Stores parsed title, type, size, checksum, entry-point, logo, and CGB-flag metadata. |
+| `CartridgeType` | `src/cartridge.rs` | Distinguishes ROM-only cartridges from currently unsupported cartridge type codes. |
+| `CartridgeError` | `src/cartridge.rs` | Represents I/O, too-short, unsupported type, ROM-size, and RAM-size errors. |
+| `validate_rom_bytes` | `src/cartridge.rs` | Checks that a ROM is large enough to contain the full cartridge header region. |
+| `load_rom_file` | `src/cartridge.rs` | Loads and validates a ROM file, returning the raw bytes for the CLI. |
+| `load_cartridge_file` | `src/cartridge.rs` | Loads a ROM file into a reusable `Cartridge`. |
+| `Bus` | `src/bus.rs` | Routes 16-bit address reads and writes to cartridge ROM and owned memory regions. |
+| `Bus::read8` | `src/bus.rs` | Reads one byte from the DMG address space. |
+| `Bus::write8` | `src/bus.rs` | Writes one byte to writable DMG address ranges and ignores unusable ranges. |
+
+## Directory Structure Rationale
+
+```text
+.
+├── Cargo.toml
+├── src/
+│   ├── main.rs
+│   ├── lib.rs
+│   ├── cartridge.rs
+│   └── bus.rs
+├── tests/
+│   └── cli.rs
+├── docs/
+│   ├── hot_to_proceed.md
+│   └── gameboy_architecture_summary.md
+├── roms/
+│   ├── blargg-gb-tests/
+│   ├── hello-world/
+│   └── mooneye/
+└── .github/
+    └── workflows/
+```
+
+- `src/main.rs` stays thin and user-facing so emulator behavior can be tested through library modules.
+- `src/lib.rs` is the public crate surface for emulator components.
+- `src/cartridge.rs` keeps ROM parsing, header metadata, cartridge type handling, and ROM-only reads together.
+- `src/bus.rs` centralizes CPU-visible memory routing so CPU execution can later depend on one memory interface.
+- `tests/cli.rs` checks the compiled binary behavior from the outside.
+- `docs/` contains implementation notes and generated project documentation.
+- `roms/` stores local ROM fixtures and upstream test ROM suites for future emulator validation.
+- `.github/workflows/` contains CI and repository automation.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,0 +1,74 @@
+<!-- generated-by: gsd-doc-writer -->
+# Configuration
+
+GameGirl currently has almost no runtime configuration. The emulator foundation is configured by Cargo metadata, repository tooling files, GitHub Actions workflow files, and the ROM path passed to the CLI.
+
+## Environment Variables
+
+No application environment variables are read by `src/main.rs`, `src/cartridge.rs`, or `src/bus.rs`.
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| None | No | None | The current Rust code does not reference environment variables. |
+
+## Config File Format
+
+| File | Format | Purpose |
+|------|--------|---------|
+| `Cargo.toml` | TOML | Defines the Rust package name, version, edition, license metadata, repository, readme, keywords, and dependencies. |
+| `Cargo.lock` | TOML-like Cargo lockfile | Records the resolved dependency graph. The current dependency graph has no third-party Rust crates. |
+| `.editorconfig` | EditorConfig | Sets UTF-8, LF endings, final newlines, four-space indentation by default, two-space YAML indentation, and Markdown trailing-space behavior. |
+| `renovate.json` | JSON | Configures Renovate. |
+| `.github/labeler.yml` | YAML | Maps changed files to repository labels. |
+| `.github/dependabot.yml` | YAML | Configures weekly GitHub Actions and Go module dependency update checks. |
+| `.github/auto_assign.yml` | YAML | Configures pull-request auto-assignment behavior. |
+| `.github/workflows/rust.yml` | YAML | Runs formatting, clippy, and tests for Rust source changes on `main`. |
+| `.github/workflows/rust-clippy.yml` | YAML | Runs a scheduled and PR/push clippy SARIF analysis workflow. |
+| `.github/workflows/dependency-review.yml` | YAML | Runs dependency review on pull requests. |
+
+`Cargo.toml` is the main project configuration file:
+
+```toml
+[package]
+name = "game_girl"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+description = "A GameBoy emulator written in Rust"
+
+[dependencies]
+```
+
+## Required vs Optional Settings
+
+The CLI requires exactly one user-provided runtime setting: a ROM path argument.
+
+| Setting | Required | Validation | Failure behavior |
+|---------|----------|------------|------------------|
+| ROM path argument | Yes | Must be present as the first positional argument. | Prints `Usage: {program} <rom.gb|rom.gbc>` and exits with failure. |
+| ROM path extension | Yes | Extension must be `.gb` or `.gbc`, case-insensitive. | Prints `File must be a .gb or .gbc file` and exits with failure. |
+| ROM file readability | Yes | `std::fs::read` must successfully read the file. | Returns a `CartridgeError::Io` message. |
+| ROM header length | Yes | ROM must be at least `MIN_CARTRIDGE_HEADER_LEN` bytes. | Returns a `CartridgeError::TooShort` message. |
+| Cartridge type | Yes | Type code `0x00` is accepted as ROM-only. | Other type codes return `CartridgeError::UnsupportedCartridgeType`. |
+| ROM size code | Yes | Codes `0x00` through `0x08` are supported. | Other codes return `CartridgeError::UnsupportedRomSize`. |
+| RAM size code | Yes | Codes `0x00` through `0x05` are supported. | Other codes return `CartridgeError::UnsupportedRamSize`. |
+
+## Defaults
+
+| Area | Default | Location |
+|------|---------|----------|
+| Cargo edition | Rust 2021 | `Cargo.toml` |
+| Runtime dependencies | No third-party Rust dependencies | `Cargo.toml` |
+| Bus WRAM | Zero-filled `[u8; 0x2000]` | `src/bus.rs` |
+| Bus OAM | Zero-filled `[u8; 0xA0]` | `src/bus.rs` |
+| Bus I/O registers | Zero-filled `[u8; 0x80]` | `src/bus.rs` |
+| Bus HRAM | Zero-filled `[u8; 0x7F]` | `src/bus.rs` |
+| Interrupt enable byte | `0` | `src/bus.rs` |
+| Unusable and unmapped reads | `0xFF` | `src/bus.rs` |
+| ROM-only writes | Ignored | `src/cartridge.rs` |
+
+## Per-Environment Overrides
+
+No development, staging, production, or test-specific application configuration files are present. The repository does not include `.env`, `.env.example`, `.env.development`, `.env.production`, Docker, or deployment-platform configuration files.
+
+CI behavior is controlled separately by files under `.github/workflows/`.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,62 @@
+<!-- generated-by: gsd-doc-writer -->
+# Development
+
+GameGirl is a Rust 2021 Cargo project. Development currently focuses on small, testable emulator-core modules and a thin CLI wrapper.
+
+## Local Setup
+
+1. Fork or clone the repository.
+2. Build the crate:
+
+   ```bash
+   cargo build
+   ```
+
+3. Run tests before changing behavior:
+
+   ```bash
+   cargo test
+   ```
+
+4. Run formatting and lint checks before opening a pull request:
+
+   ```bash
+   cargo fmt --all
+   cargo clippy --all-targets -- -D warnings
+   ```
+
+No `.env` file, local service, database, or generated source step is required.
+
+## Build Commands
+
+| Command | Description |
+|---------|-------------|
+| `cargo build` | Compiles the binary and library crate. |
+| `cargo run -- roms/hello-world/hello-world.gb` | Runs the CLI against the checked-in hello-world ROM fixture. |
+| `cargo test` | Runs unit tests, integration tests, and doc tests. |
+| `cargo test cartridge` | Runs tests whose names or module paths include `cartridge`. |
+| `cargo test bus` | Runs tests whose names or module paths include `bus`. |
+| `cargo test --test cli` | Runs the CLI integration tests in `tests/cli.rs`. |
+| `cargo fmt --all` | Formats all Rust code with rustfmt. |
+| `cargo fmt --all -- --check` | Checks Rust formatting without rewriting files. |
+| `cargo clippy --all-targets -- -D warnings` | Runs clippy for all targets and treats warnings as errors. |
+
+## Code Style
+
+- Rust code follows standard rustfmt formatting. The repository uses `.editorconfig` for editor defaults and `.github/workflows/rust.yml` runs `cargo fmt --all`.
+- Clippy is used for linting. `.github/workflows/rust.yml` runs `cargo clippy`, and `.github/workflows/rust-clippy.yml` runs a SARIF-producing clippy analysis workflow.
+- Keep CLI behavior in `src/main.rs`; put reusable emulator logic in library modules exported by `src/lib.rs`.
+- Prefer small unit tests for pure emulator behavior and integration tests for compiled CLI behavior.
+- Avoid adding dependencies unless they remove meaningful implementation risk; `Cargo.toml` currently has an empty `[dependencies]` section.
+
+## Branch Conventions
+
+No formal branch naming convention is documented in the repository. Use short descriptive names that identify the work area, such as `feature/add-cpu` for feature work or `fix/rom-loading-error` for bug fixes.
+
+## PR Process
+
+- Keep each pull request focused on one subsystem or behavior change.
+- Run `cargo fmt --all`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` locally before requesting review.
+- Include tests for new cartridge, bus, CPU, timer, PPU, or CLI behavior.
+- Describe which ROM fixtures or focused tests were used for validation.
+- Watch CI results from `.github/workflows/rust.yml`, `.github/workflows/rust-clippy.yml`, and `.github/workflows/dependency-review.yml`.

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -1,0 +1,68 @@
+<!-- generated-by: gsd-doc-writer -->
+# Getting Started
+
+This guide gets a local GameGirl checkout to the point where it builds, runs, and loads a ROM file through the current CLI.
+
+## Prerequisites
+
+- Rust and Cargo are required.
+- The repository does not pin an exact Rust version. `Cargo.toml` does not declare a `rust-version`, and no Rust toolchain pin file is present.
+- CI installs the stable Rust toolchain for clippy analysis in `.github/workflows/rust-clippy.yml`.
+- No database, service, emulator frontend, or environment-variable setup is required.
+
+## Installation Steps
+
+1. Clone the repository:
+
+   ```bash
+   git clone https://github.com/smirror/GameGirl.git
+   ```
+
+2. Enter the project directory:
+
+   ```bash
+   cd GameGirl
+   ```
+
+3. Build the Rust crate:
+
+   ```bash
+   cargo build
+   ```
+
+4. Run the full test suite:
+
+   ```bash
+   cargo test
+   ```
+
+## First Run
+
+Use the checked-in hello-world ROM fixture:
+
+```bash
+cargo run -- roms/hello-world/hello-world.gb
+```
+
+The current CLI prints the number of bytes loaded from the ROM:
+
+```text
+Loaded ROM: 32768 bytes
+```
+
+## Common Setup Issues
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `Usage: ... <rom.gb\|rom.gbc>` | No ROM path was provided. | Pass a `.gb` or `.gbc` path after `--`. |
+| `File must be a .gb or .gbc file` | The path extension is not supported. | Use a file ending in `.gb` or `.gbc`; uppercase variants such as `.GBC` are accepted. |
+| `could not read ROM ...` | The path does not exist or cannot be read. | Check the file path and filesystem permissions. |
+| `ROM is too short ... expected at least 336 bytes` | The file is smaller than the Game Boy cartridge header region. | Use a real Game Boy ROM or a test fixture with at least `0x150` bytes. |
+| `unsupported cartridge type ...` | The ROM uses a cartridge type that is not implemented yet. | Use a ROM-only cartridge for the current emulator foundation. |
+
+## Next Steps
+
+- Read `docs/ARCHITECTURE.md` for the module layout and data flow.
+- Read `docs/DEVELOPMENT.md` before changing code.
+- Read `docs/TESTING.md` for focused test commands and CI behavior.
+- Read `docs/CONFIGURATION.md` for supported runtime inputs and repository configuration files.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,75 @@
+<!-- generated-by: gsd-doc-writer -->
+# Testing
+
+GameGirl uses Cargo's built-in Rust test harness. The current test suite covers cartridge parsing and ROM-only behavior, Bus address routing, and compiled CLI behavior.
+
+## Test Framework And Setup
+
+- Test framework: Cargo's built-in Rust test harness.
+- Unit tests live beside implementation code in `src/cartridge.rs` and `src/bus.rs`.
+- CLI integration tests live in `tests/cli.rs`.
+- No third-party test framework is configured in `Cargo.toml`.
+- No global test setup file is required.
+
+## Running Tests
+
+Run everything:
+
+```bash
+cargo test
+```
+
+Run cartridge-focused tests:
+
+```bash
+cargo test cartridge
+```
+
+Run Bus-focused tests:
+
+```bash
+cargo test bus
+```
+
+Run only the CLI integration test target:
+
+```bash
+cargo test --test cli
+```
+
+Run formatting and lint checks used during local verification:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets -- -D warnings
+```
+
+## Writing New Tests
+
+- Put pure module tests inside the same source file under `#[cfg(test)] mod tests`.
+- Put compiled binary behavior tests under `tests/`.
+- Use descriptive snake_case test names such as `rejects_rom_shorter_than_header` or `reports_missing_rom_file`.
+- Keep emulator fixtures small where possible. `tests/cli.rs` creates temporary ROM bytes in the test instead of depending on a large external fixture.
+- Use checked-in ROM suites under `roms/` only when the emulator behavior being tested is implemented enough to make the result meaningful.
+
+Current examples:
+
+| Area | File | Coverage |
+|------|------|----------|
+| Cartridge validation and metadata | `src/cartridge.rs` | Header length, title parsing, ROM/RAM size codes, unsupported type codes, ROM-only reads/writes. |
+| Bus routing | `src/bus.rs` | ROM delegation, WRAM/Echo RAM mirroring, OAM, I/O, HRAM, IE, unusable range, unmapped range behavior. |
+| CLI behavior | `tests/cli.rs` | Valid ROM load, `.GBC` extension handling, missing argument, invalid suffix, missing file, too-short ROM. |
+
+## Coverage Requirements
+
+No coverage threshold is configured. There is no `tarpaulin`, `llvm-cov`, `grcov`, or coverage configuration file in the repository.
+
+## CI Integration
+
+| Workflow | Trigger | Test-related behavior |
+|----------|---------|-----------------------|
+| `.github/workflows/rust.yml` | Push or pull request to `main` when Rust source files under `src/` change | Runs `cargo fmt --all`, `cargo clippy`, and `cargo test --verbose`. |
+| `.github/workflows/rust-clippy.yml` | Push, pull request, and a monthly schedule | Installs the stable Rust toolchain with clippy and uploads SARIF results. |
+| `.github/workflows/dependency-review.yml` | Pull request to `main` | Runs `actions/dependency-review-action@v4`. |
+
+The checked-in ROM directories `roms/blargg-gb-tests/`, `roms/mooneye/`, and `roms/hello-world/` are available for future emulator validation, but most of those ROMs are not yet wired into automated tests.

--- a/docs/gameboy_architecture_summary.md
+++ b/docs/gameboy_architecture_summary.md
@@ -1,0 +1,188 @@
+# Game Boy 仕様まとめ
+
+`docs/hot_to_proceed.md` の「1. 先に読む資料」を実際に読んだうえで、
+DMG 向けエミュレータ実装に必要な仕様を絞って整理したメモです。
+
+## 1. 前提
+
+- 実装の初期ターゲットは DMG 互換に絞るのが妥当です。
+- Game Boy は Sharp SM83 系の 8-bit CPU を中心に、RAM、PPU、Timer、Joypad などを SoC にまとめた構成です。
+- アドレス空間は 16-bit、標準クロックは 4.194304 MHz です。
+- 通常速度では 1 M-cycle = 4 T-cycle = 4 dots と考えて実装すると整理しやすいです。
+
+## 2. メモリマップ
+
+DMG 実装でまず押さえるべき領域は次の通りです。
+
+| 範囲 | 用途 | 実装メモ |
+| --- | --- | --- |
+| `0000-3FFF` | ROM bank 0 | 固定バンク |
+| `4000-7FFF` | switchable ROM | MBC 対応時に切り替え |
+| `8000-9FFF` | VRAM | PPU 使用中は CPU から制約あり |
+| `A000-BFFF` | External RAM | MBC ごとに有効化やバンク切り替えあり |
+| `C000-DFFF` | WRAM | 本体 RAM |
+| `E000-FDFF` | Echo RAM | `C000-DDFF` のミラー。基本は使わない前提でよい |
+| `FE00-FE9F` | OAM | Sprite 属性 |
+| `FEA0-FEFF` | unusable | 禁止領域として扱うのが安全 |
+| `FF00-FF7F` | I/O registers | Joypad, Timer, LCD, DMA, Audio など |
+| `FF80-FFFE` | HRAM | 高速ワークエリア |
+| `FFFF` | `IE` | 割り込み有効化レジスタ |
+
+補足:
+
+- `0000-00FF` には `RST` ベクタと割り込みベクタが置かれます。
+- 割り込みベクタは `0040`, `0048`, `0050`, `0058`, `0060` です。
+- `0100-014F` はカートリッジヘッダです。エントリポイントや MBC 種別を読む必要があります。
+
+## 3. CPU
+
+### 3.1. レジスタ
+
+- 16-bit レジスタは `AF`, `BC`, `DE`, `HL`, `SP`, `PC` です。
+- `AF` の下位 8-bit はフラグで、意味があるのは `Z`, `N`, `H`, `C` の 4 bit だけです。
+
+### 3.2. フラグ
+
+- `Z`: 結果が 0 のときに立つ
+- `N`: 直前が減算系なら立つ
+- `H`: 下位 nibble の桁上がり/桁借りに使う
+- `C`: 桁上がり/桁借り、rotate/shift の繰り出しに使う
+
+`DAA` は `N/H/C` の扱いを間違えると破綻しやすいので、初期段階から特別扱い前提で実装した方がよいです。
+
+### 3.3. 命令セットの見方
+
+- CPU は可変長命令です。
+- 命令デコードは「通常 opcode」と `CB` prefix の 2 段で考えると整理しやすいです。
+- Z80 に似ていますが別物なので、Z80 と同一視しない方が安全です。
+- オペコード表は実装時の引き当て表として有用ですが、細かな挙動は `Pan Docs` や実機準拠テストで裏取りする必要があります。
+
+### 3.4. DMG 起動直後の代表値
+
+DMG の初期値として最低限固定で持ってよい値:
+
+- `PC = 0x0100`
+- `SP = 0xFFFE`
+- `A = 0x01`
+- `B = 0x00`
+- `C = 0x13`
+- `D = 0x00`
+- `E = 0xD8`
+- `H = 0x01`
+- `L = 0x4D`
+- `IE = 0x00`
+
+注意:
+
+- `F` の一部ビットや一部 I/O レジスタは世代や起動経路で差が出るため、厳密再現が必要になるまでは DMG 前提で揃えるのが現実的です。
+
+## 4. 割り込み
+
+### 4.1. 基本構造
+
+- `IME` は CPU 内部フラグで、割り込み全体の許可/禁止を制御します。
+- `IE` は `FFFF`、`IF` は `FF0F` にあります。
+- 割り込み優先度は `VBlank > LCD > Timer > Serial > Joypad` です。
+
+### 4.2. 実装上の重要点
+
+- ゲーム開始時点では `IME = 0` です。
+- `ei` の効果は即時ではなく、1 命令遅れて反映されます。
+- 割り込み受理時は、CPU が `IF` 対象ビットを下ろし、`IME` を 0 にし、現在の `PC` を push してベクタへ飛びます。
+- 割り込み遷移全体は 5 M-cycle です。
+
+この部分は `HALT` 周りの不具合やタイミングと密結合なので、後で `mooneye` でも検証する前提で実装した方がよいです。
+
+## 5. Timer
+
+### 5.1. レジスタ
+
+- `DIV (FF04)`
+- `TIMA (FF05)`
+- `TMA (FF06)`
+- `TAC (FF07)`
+
+### 5.2. 実装の考え方
+
+- `DIV` は単なる独立カウンタではなく、内部 system counter の一部を見せていると考えると実装しやすいです。
+- `TAC` はその内部カウンタの特定 bit を選び、その falling edge で `TIMA` を進めます。
+- したがって、`DIV` 書き込みで counter をリセットしたときや、`TAC` の周波数選択を変えたときに即座に 1 tick 発生するケースがあります。
+
+### 5.3. 見落としやすい挙動
+
+- `TIMA` overflow 時は、その場でただちに `TMA` が入るのではなく、1 M-cycle 後に reload と `IF.Timer` 設定が起きます。
+- overflow 直後の 1 M-cycle は `TIMA == 0x00` になります。
+- この 1 M-cycle の隙間で `TIMA` / `TMA` へ書いたときの挙動は特殊です。
+
+Timer は後から直すと CPU テスト全体に波及するので、最初から「内部 counter ベース」で実装するのが無難です。
+
+## 6. PPU
+
+### 6.1. フレーム構造
+
+- 1 frame は 154 scanlines
+- 可視行は最初の 144 lines
+- 1 frame は 70224 dots
+- 垂直同期は約 59.7 Hz
+- 解像度は `160x144`
+
+### 6.2. PPU mode
+
+| Mode | 内容 | 長さ |
+| --- | --- | --- |
+| `2` | OAM scan | 80 dots |
+| `3` | drawing | 172-289 dots |
+| `0` | HBlank | `376 - mode3` dots |
+| `1` | VBlank | 4560 dots |
+
+### 6.3. CPU からのアクセス制約
+
+- VRAM は Mode `0-2` でアクセス可能
+- OAM は基本的に Mode `0-1` でアクセス可能
+- Mode `3` 中は VRAM/OAM とも CPU から触れない前提でよいです
+- アクセス不可時の write は無視、read は不定値扱いです
+
+この制約があるため、PPU 未実装の段階でも「今の mode に応じてメモリアクセスを拒否する」形だけ先に作っておく価値があります。
+
+### 6.4. Sprite の最低限仕様
+
+- OBJ は `8x8` または `8x16`
+- 同時に保持できる OBJ は最大 40
+- 1 scanline に描画できる OBJ は最大 10
+
+## 7. 実装時の優先順位
+
+仕様を読んだうえで、最初の実装優先順位は次でよいです。
+
+1. DMG のメモリマップを固定値で作る
+2. CPU レジスタ、命令 fetch/decode/execute を作る
+3. `IE` / `IF` / `IME` と timer をつなぐ
+4. PPU の mode 遷移だけ先に作る
+5. VRAM/OAM アクセス制約を反映する
+6. その後に背景描画、sprite 描画、MBC へ進む
+
+## 8. ソースの使い分け
+
+- `Pan Docs`
+  - まず最優先で見る基準資料。メモリマップ、割り込み、PPU、タイマの仕様確認に使う。
+- `Game Boy: Complete Technical Reference`
+  - クロック、CPU コアの立ち位置、世代差、電気的な背景を確認したいときに使う。
+- `Gameboy CPU (LR35902) instruction set`
+  - opcode の一覧表として使う。命令の網羅確認に便利。
+- `Game Boy CPU Manual`
+  - 命令ごとの動作確認の補助に使う。ただし最終判断は `Pan Docs` とテスト ROM を優先する。
+
+## 9. 参考元
+
+- [Pan Docs: Memory Map](https://gbdev.io/pandocs/Memory_Map.html)
+- [Pan Docs: CPU Registers and Flags](https://gbdev.io/pandocs/CPU_Registers_and_Flags.html)
+- [Pan Docs: CPU Instruction Set](https://gbdev.io/pandocs/CPU_Instruction_Set.html)
+- [Pan Docs: Interrupts](https://gbdev.io/pandocs/Interrupts.html)
+- [Pan Docs: Timer obscure behaviour](https://gbdev.io/pandocs/Timer_Obscure_Behaviour.html)
+- [Pan Docs: Accessing VRAM and OAM](https://gbdev.io/pandocs/Accessing_VRAM_and_OAM.html)
+- [Pan Docs: Rendering overview](https://gbdev.io/pandocs/Rendering.html)
+- [Pan Docs: Power-Up Sequence](https://gbdev.io/pandocs/Power_Up_Sequence.html)
+- [Pan Docs: Specifications](https://gbdev.io/pandocs/Specifications.html)
+- [Game Boy: Complete Technical Reference](https://gekkio.fi/files/gb-docs/gbctr.pdf)
+- [Gameboy CPU (LR35902) instruction set](https://www.pastraiser.com/cpu/gameboy/gameboy_opcodes.html)
+- [Game Boy CPU Manual](http://marc.rawer.de/Gameboy/Docs/GBCPUman.pdf)

--- a/docs/hot_to_proceed.md
+++ b/docs/hot_to_proceed.md
@@ -1,77 +1,113 @@
-# ゲームボーイの実装の進め方
+# ゲームボーイ実装の進め方
 
-## 1. ゲームボーイの仕様を理解する
+このドキュメントは、[README.md](../README.md) にある参照資料と実装例を起点に、
+Game Boy エミュレータ実装をどう進めるかを整理したものです。
 
-### 1.1. 資料を読み込む
-- [ ] PanDocなどの資料を参考に読み進める
-    - [The Ultimate Game Boy Talk (33c3)](https://www.youtube.com/watch?v=HyzD8pNlpwI)
-    - [Pandocs](https://gbdev.io/pandocs/)
-    - [Gameboy CPU (LR35902) instruction set](http://www.pastraiser.com/cpu/gameboy/gameboy_opcodes.html):
-      ゲームボーイのCPU (LR35902) の全命令をまとめた表． 一覧性が高く，オペランドのフォーマットや命令のクロック数も記載されているため，
-      命令デコーダの作成に重宝する．ただし，一部のクロック数は間違っているという罠がある．
-    - [Game Boy CPU Manual](http://marc.rawer.de/Gameboy/Docs/GBCPUman.pdf): CPU の各命令の詳しい動作が記載されている．フラグがセット・クリアされる条件など，
-      上の表よりも詳しい．ただし，一部の命令 (DAA命令など) の動作はこの資料でもまだ情報が足りないため，他の資料をあたることになる．
-    - [gbdev/awesome-gbdev](https://github.com/gbdev/awesome-gbdev)
-      ：ゲームボーイ開発に関するリソースが網羅されている。
-    - [akatsuki105/gb-docs-ja](https://github.com/akatsuki105/gb-docs-ja)
-    - [Game Boy Programming Manual](https://web.archive.org/web/20150513170240/http://www.chrisantonellis.com:80/files/gameboy/gb-programming-manual.pdf)
-      ：Nintendo in Americaが出した（？）公式の（？）仕様書。細かい処理などを確認するときに便利です。
-    - [Game Boy: Complete Technical Reference](https://gekkio.fi/files/gb-docs/gbctr.pdf)
-      ：ハードウェアの物理的な特性まで踏み込んだ詳細な技術リファレンス。
+## 1. 先に読む資料
 
-### 1.2. 設計と方針の検討
-- [ ] ゲームボーイの構造を理解し、エミュレータ用にどう再構築するか考える
-    - [ ] ゲームボーイエミュレータのコード規模は中規模のため、単体テスト可能な実装ができるように作る必要がある
-    - [ ] [blargg-gb-tests](https://github/smirror/GmaeGirl/roms/blargg-gb-tests) :テストROMは実機で通ることが確認されているため、ドキュメントよりも信頼できる。
-    - [ ] 循環参照（密結合）にならないように、バスを中心とした設計やパッケージ構成（Traitによる抽象化など）を検討する
+調査結果は [gameboy_architecture_summary.md](./gameboy_architecture_summary.md) にまとめた。
 
-## 2. 実装のロードマップ
+### 1.1. 仕様と命令セット
+- [Pandocs](https://gbdev.io/pandocs/)
+  - まず最初に読む基礎資料。メモリマップ、レジスタ、PPU、タイマ、割り込みの全体像を掴む。
+- [Gameboy CPU (LR35902) instruction set](http://www.pastraiser.com/cpu/gameboy/gameboy_opcodes.html)
+  - 命令デコーダを作るときの一覧表として便利。ただし一部のクロック数は誤りがあるので、他資料で確認する。
+- [Game Boy CPU Manual](http://marc.rawer.de/Gameboy/Docs/GBCPUman.pdf)
+  - 各命令の詳しい動作やフラグ更新条件を確認する用途で使う。
+- [Game Boy Programming Manual](https://web.archive.org/web/20150513170240/http://www.chrisantonellis.com:80/files/gameboy/gb-programming-manual.pdf)
+  - 公式寄りの資料として、レジスタや周辺機能の挙動確認に役立つ。
+- [Game Boy: Complete Technical Reference](https://gekkio.fi/files/gb-docs/gbctr.pdf)
+  - さらに細かいハードウェア挙動を確認したいときの詳細リファレンス。
 
-ゲームボーイエミュレータの実装は、以下の順序で進めるのが一般的です。
+### 1.2. 参考リンク集
+- [gbdev/awesome-gbdev](https://github.com/gbdev/awesome-gbdev)
+  - 追加資料やツール、テスト ROM を探す入口として使う。
+- [akatsuki105/gb-docs-ja](https://github.com/akatsuki105/gb-docs-ja)
+  - 英語資料で詰まった箇所の補助として参照する。
 
-### 2.1. メモリバス (Bus) とメモリの実装
-- [ ] メモリアドレスマップの実装
-    - 各デバイス（ROM, RAM, PPU, APU, Joypad, Timer等）のアドレス範囲を定義する
-- [ ] 16bitアドレス、8bitデータの読み書きインターフェース（Read/Write）を定義する
-- [ ] メモリバスを通じてCPUからメモリへアクセスできるようにする
+## 2. 参考にする実装
 
-### 2.2. CPU (LR35902) の実装
-- [ ] レジスタ（A, B, C, D, E, H, L, F, SP, PC）の定義
-- [ ] 命令デコーダの実装
-- [ ] 各命令（Load, Arithmetic, Bit, Jump, Call, Return等）のロジック実装
-- [ ] [blargg-gb-tests/cpu_instrs](https://github.com/smirror/GameGirl/tree/main/roms/blargg-gb-tests/cpu_instrs) を利用したデバッグ
-    - 各命令が正しく動作することを確認する
+README にまとまっている既存実装は、設計の比較対象として一度眺めておくとよいです。
+特に「Bus をどう切るか」「CPU と周辺機器の依存をどう持たせるか」を見る価値があります。
 
-### 2.3. タイマーと割り込みの実装
-- [ ] タイマー（DIV, TIMA, TMA, TAC）の実装
-- [ ] 割り込みフラグ（IF）と割り込み有効化（IE）の制御
-- [ ] [blargg-gb-tests/instr_timing](https://github.com/smirror/GameGirl/tree/main/roms/blargg-gb-tests/instr_timing) を利用したクロック精度の確認
+### 2.1. Rust
+- [tanakh/tgbr](https://github.com/tanakh/tgbr)
+- [keichi/gbr](https://github.com/keichi/gbr)
 
-### 2.4. PPU (Picture Processing Unit) の実装
-- [ ] 背景（Background）の描画実装
-- [ ] ウィンドウ（Window）の描画実装
-- [ ] オブジェクト（Sprite/OAM）の描画実装
-- [ ] VRAM, OAMへのアクセス制御
-- [ ] 描画タイミング（Mode 0, 1, 2, 3）と VBlank 割り込みの実装
+### 2.2. Go
+- [akatsuki105/worldwide](https://github.com/akatsuki105/worldwide)
+- [mohanson/dwangb](https://github.com/akashin/dwangb)
 
-### 2.5. 入力 (Joypad) の実装
-- [ ] ボタン入力（十字キー、A, B, Select, Start）の状態管理
-- [ ] 入力状態の変化に伴う割り込みの実装
+### 2.3. Ruby
+- [sacckey/rubyboy](https://github.com/sacckey/rubyboy)
 
-### 2.6. カートリッジ (MBC) の実装
-- [ ] MBC0 (No MBC), MBC1, MBC3 などのメモリバンクコントローラの実装
-- [ ] 外部RAM（SRAM）の保存・読み込み
+## 3. テスト ROM と検証方針
 
-### 2.7. APU (Audio Processing Unit) の実装
-- [ ] 各チャンネル（Pulse 1, Pulse 2, Wave, Noise）の実装
-- [ ] 波形データの出力とゲームエンジン（オーディオ出力）への接続
+- [roms](../roms/)
+  - このリポジトリに検証用 ROM がまとまっている。
+- [blargg-gb-tests](../roms/blargg-gb-tests/)
+  - CPU 命令、タイミング、周辺機器の基本検証に使う。
+- [mooneye](../roms/mooneye/)
+  - blargg だけでは拾いきれない細かなハードウェア挙動の検証に使う。
 
-## 3. 参考ブログ・実装例（READMEより抜粋）
+テスト ROM は仕様書より信頼できる場面があります。実装中に資料同士で記述が食い違ったら、
+まずテスト ROM の結果を基準に確認する方が堅いです。
+
+## 4. 実装方針
+
+- Bus を中心に据えて、CPU / PPU / Timer / Joypad / Cartridge を疎結合にする。
+- 単体テストしやすいように、レジスタ操作・命令実行・メモリアクセスを小さく分離する。
+- CPU の命令実装を先に固め、その後にタイマ・割り込み・PPU を積み上げる。
+- 仕様を読むだけで確定しない部分は、既存実装とテスト ROM の両方で裏を取る。
+
+## 5. 実装のロードマップ
+
+### 5.1. メモリバス (Bus) とメモリ
+- [ ] メモリアドレスマップを定義する
+- [ ] 16-bit address / 8-bit data の read/write インターフェースを作る
+- [ ] CPU から各デバイスへ Bus 経由でアクセスできるようにする
+
+### 5.2. CPU (LR35902)
+- [ ] レジスタ `A, B, C, D, E, H, L, F, SP, PC` を定義する
+- [ ] 命令フェッチ、デコード、実行の流れを実装する
+- [ ] Load / Arithmetic / Bit / Jump / Call / Return を順に実装する
+- [ ] [cpu_instrs](../roms/blargg-gb-tests/cpu_instrs/) で命令実装を検証する
+
+### 5.3. タイマと割り込み
+- [ ] `DIV`, `TIMA`, `TMA`, `TAC` を実装する
+- [ ] `IF`, `IE`, `IME` を含む割り込み制御を実装する
+- [ ] [instr_timing](../roms/blargg-gb-tests/instr_timing/) でクロック精度を確認する
+
+### 5.4. PPU
+- [ ] Background の描画を実装する
+- [ ] Window の描画を実装する
+- [ ] Sprite / OAM の描画を実装する
+- [ ] VRAM / OAM のアクセス制御を実装する
+- [ ] Mode 0-3 と VBlank 割り込みを実装する
+
+### 5.5. 入力 (Joypad)
+- [ ] 十字キー、A、B、Select、Start の状態管理を実装する
+- [ ] 入力変化に伴う割り込みを実装する
+
+### 5.6. カートリッジ (MBC)
+- [ ] MBC0, MBC1, MBC3 など主要 MBC を実装する
+- [ ] 外部 RAM の保存と読み込みを実装する
+
+### 5.7. APU
+- [ ] Pulse 1 / Pulse 2 / Wave / Noise を順に実装する
+- [ ] オーディオ出力に接続する
+
+## 6. 参考ブログ
+
+README にまとまっているブログは、詰まりやすいポイントの当たりを付けるのに向いています。
+
 - [ゲームボーイのエミュレータを自作した話](https://keichi.dev/post/write-yourself-a-game-boy-emulator/)
-    - 全体像の把握に最適。実装のフェーズ分けが参考になる。
 - [ゲームボーイを作る（１）](https://www.tech-diningyo.info/entry/2021/07/10/222140)
-    - PPUのタイミングやレジスタの詳細が詳しい。
+- [ゲームボーイのエミュレータをGoで作った話](https://zenn.dev/akatsuki/articles/ec95ab95f0e89ea8c38f)
+- [C++でゲームボーイエミュレータを自作しています](https://voidproc.com/blog/archives/664)
+- [脱・初級者のための自作GBエミュレータ開発](https://www.docswell.com/s/linoscope/ZNRRXL-game-boy-emulator-ocaml)
 - [OCaml でゲームボーイエミュレータを書いた話](https://qiita.com/linoscope/items/244d931aaae07df2c27e)
-    - 複雑な割り込みやタイマーの挙動、デバッグ手法について詳しい。
+- [Rubyでゲームボーイのエミュレータを作った](https://zenn.dev/sacckey/articles/05b6eb6ea89662)
 - [AQBoy: Yet Another Game Boy Emulator 開発記](https://hackmd.io/@anqou/HJcvRrwy9)
-    - 実装中にハマりやすいポイント（DAA命令、タイマーのインクリメントタイミング等）がまとめられている。
+- [GameBoy Emulation in JavaScript](https://imrannazar.com/series/gameboy-emulation-in-javascript)
+- [自作ゲームボーイエミュレータメモ](https://qiita.com/kmtoki/items/578e8e57ab0e76590d6d)

--- a/docs/ja/ARCHITECTURE.md
+++ b/docs/ja/ARCHITECTURE.md
@@ -1,0 +1,82 @@
+<!-- generated-by: gsd-doc-writer -->
+# アーキテクチャ
+
+GameGirl は Rust 製の Game Boy エミュレータ基盤です。現在の実行ファイルは `.gb` / `.gbc` の ROM パスを受け取り、ROM をバイナリとして読み込み、カートリッジヘッダーを表示し、再利用可能な cartridge / bus モジュールを公開します。
+
+## システム概要
+
+このプロジェクトは、小さな Rust バイナリと再利用可能なライブラリ crate に分かれています。`src/main.rs` は CLI 引数、ユーザー向けエラー、ヘッダー表示を担当します。エミュレータ本体の処理は `src/lib.rs` 配下にあり、現在は `cartridge` と `bus` モジュールを公開しています。
+
+現在の主な入力は ROM ファイルです。出力は、読み込んだバイト数、解析したヘッダー情報、または読み込み・解析エラーです。
+
+## コンポーネント図
+
+```mermaid
+graph TD
+    CLI["src/main.rs"]
+    Library["src/lib.rs"]
+    Cartridge["src/cartridge.rs"]
+    Bus["src/bus.rs"]
+    RomFile["ROM file (.gb/.gbc)"]
+
+    RomFile --> CLI
+    CLI --> Cartridge
+    Library --> Cartridge
+    Library --> Bus
+    Bus --> Cartridge
+```
+
+## データフロー
+
+1. `src/main.rs` が最初の CLI 引数を読み、拡張子が `.gb` または `.gbc` か確認します。
+2. CLI は `std::fs::read` で ROM をバイナリ bytes として読みます。
+3. `CartridgeHeader::parse` がカートリッジヘッダーを解析し、タイトル、カートリッジ種別、ROM/RAM サイズなどを表示します。
+4. `Cartridge::from_bytes` がサポート済みの ROM-only カートリッジか検証します。MBC など未対応の種別は `UnsupportedCartridgeType` として明示的に拒否します。
+5. `Bus::new` は `Cartridge` を受け取り、ROM、WRAM、OAM、I/O、HRAM、IE など、現在実装済みの CPU 可視メモリ範囲を所有します。
+6. 今後の CPU 実装は、ROM や RAM を直接読むのではなく `Bus::read8` / `Bus::write8` を通してアクセスします。
+
+## 主要な抽象化
+
+| 抽象化 | 場所 | 役割 |
+|--------|------|------|
+| `Cartridge` | `src/cartridge.rs` | ROM bytes を所有し、ROM-only カートリッジの読み書きを提供します。 |
+| `CartridgeHeader` | `src/cartridge.rs` | タイトル、種別、サイズ、チェックサム、エントリポイント、ロゴ、CGB flag などのヘッダー情報を保持します。 |
+| `CartridgeType` | `src/cartridge.rs` | ROM-only と未対応カートリッジ種別を区別します。 |
+| `CartridgeError` | `src/cartridge.rs` | I/O、短すぎる ROM、未対応種別、未対応 ROM/RAM サイズなどのエラーを表します。 |
+| `validate_rom_bytes` | `src/cartridge.rs` | ROM がカートリッジヘッダー領域を含む長さか確認します。 |
+| `load_rom_file` | `src/cartridge.rs` | CLI 用に ROM ファイルを読み込み、検証したうえで raw bytes を返します。 |
+| `load_cartridge_file` | `src/cartridge.rs` | ROM ファイルを `Cartridge` として読み込みます。 |
+| `Bus` | `src/bus.rs` | 16-bit アドレス空間の read/write を、カートリッジ ROM や内部メモリへルーティングします。 |
+| `Bus::read8` | `src/bus.rs` | DMG アドレス空間から 1 byte 読みます。 |
+| `Bus::write8` | `src/bus.rs` | 書き込み可能な範囲へ 1 byte 書き込み、未使用範囲は無視します。 |
+
+## ディレクトリ構成
+
+```text
+.
+├── Cargo.toml
+├── src/
+│   ├── main.rs
+│   ├── lib.rs
+│   ├── cartridge.rs
+│   └── bus.rs
+├── tests/
+│   └── cli.rs
+├── docs/
+│   ├── hot_to_proceed.md
+│   ├── gameboy_architecture_summary.md
+│   └── ja/
+├── roms/
+│   ├── blargg-gb-tests/
+│   ├── hello-world/
+│   └── mooneye/
+└── .github/
+    └── workflows/
+```
+
+- `src/main.rs` は薄い CLI 境界として保ちます。
+- `src/lib.rs` はエミュレータ部品を公開する crate API です。
+- `src/cartridge.rs` は ROM 読み込み、ヘッダー解析、種別判定、ROM-only 読み取りをまとめます。
+- `src/bus.rs` は CPU から見えるメモリアクセスの入口です。
+- `tests/cli.rs` はコンパイル済みバイナリの振る舞いを外側から確認します。
+- `roms/` は将来の検証に使う ROM fixture とテスト ROM 群を置きます。

--- a/docs/ja/CONFIGURATION.md
+++ b/docs/ja/CONFIGURATION.md
@@ -1,0 +1,74 @@
+<!-- generated-by: gsd-doc-writer -->
+# 設定
+
+GameGirl には、現時点で複雑な実行時設定はありません。主な設定は Cargo metadata、リポジトリ設定、GitHub Actions、そして CLI に渡す ROM パスです。
+
+## 環境変数
+
+`src/main.rs`、`src/cartridge.rs`、`src/bus.rs` はアプリケーション用の環境変数を読みません。
+
+| 変数 | 必須 | デフォルト | 説明 |
+|------|------|------------|------|
+| なし | いいえ | なし | 現在の Rust コードは環境変数を参照していません。 |
+
+## 設定ファイル
+
+| ファイル | 形式 | 用途 |
+|----------|------|------|
+| `Cargo.toml` | TOML | package 名、version、edition、license、repository、readme、keywords、dependencies を定義します。 |
+| `Cargo.lock` | Cargo lockfile | 依存グラフを記録します。現在、外部 Rust crate はありません。 |
+| `.editorconfig` | EditorConfig | UTF-8、LF、最終改行、基本 4 spaces、YAML 2 spaces、Markdown の trailing spaces 設定を定義します。 |
+| `renovate.json` | JSON | Renovate 設定です。 |
+| `.github/labeler.yml` | YAML | 変更ファイルに応じた GitHub label を定義します。 |
+| `.github/dependabot.yml` | YAML | GitHub Actions と Go module の週次更新チェックを定義します。 |
+| `.github/auto_assign.yml` | YAML | Pull request の auto assign を設定します。 |
+| `.github/workflows/rust.yml` | YAML | Rust source 変更時に format、clippy、test を実行します。 |
+| `.github/workflows/rust-clippy.yml` | YAML | clippy SARIF analysis を実行します。 |
+| `.github/workflows/dependency-review.yml` | YAML | Pull request で dependency review を実行します。 |
+
+`Cargo.toml` の主要部分は次の通りです。
+
+```toml
+[package]
+name = "game_girl"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+description = "A GameBoy emulator written in Rust"
+
+[dependencies]
+```
+
+## 必須設定と任意設定
+
+CLI 実行時に必須なのは、最初の位置引数として渡す ROM パスです。
+
+| 設定 | 必須 | 検証内容 | 失敗時の挙動 |
+|------|------|----------|--------------|
+| ROM パス引数 | はい | 最初の位置引数として存在すること。 | `Usage: {program} <rom.gb\|rom.gbc>` を表示して失敗終了します。 |
+| ROM 拡張子 | はい | `.gb` または `.gbc`。大文字小文字は区別しません。 | `File must be a .gb or .gbc file` を表示して失敗終了します。 |
+| ROM ファイル読み込み | はい | `std::fs::read` で読めること。 | 読み込み失敗を表示して失敗終了します。 |
+| ROM ヘッダー長 | はい | 少なくとも `MIN_CARTRIDGE_HEADER_LEN` bytes あること。 | `CartridgeError::TooShort` を表示します。 |
+| カートリッジ種別 | はい | `0x00` は ROM-only として受け付けます。 | その他は `CartridgeError::UnsupportedCartridgeType` を返します。 |
+| ROM サイズコード | はい | `0x00` から `0x08` をサポートします。 | その他は `CartridgeError::UnsupportedRomSize` を返します。 |
+| RAM サイズコード | はい | `0x00` から `0x05` をサポートします。 | その他は `CartridgeError::UnsupportedRamSize` を返します。 |
+
+## デフォルト値
+
+| 項目 | デフォルト | 場所 |
+|------|------------|------|
+| Cargo edition | Rust 2021 | `Cargo.toml` |
+| Runtime dependencies | 外部 Rust dependency なし | `Cargo.toml` |
+| Bus WRAM | zero-filled `[u8; 0x2000]` | `src/bus.rs` |
+| Bus OAM | zero-filled `[u8; 0xA0]` | `src/bus.rs` |
+| Bus I/O registers | zero-filled `[u8; 0x80]` | `src/bus.rs` |
+| Bus HRAM | zero-filled `[u8; 0x7F]` | `src/bus.rs` |
+| Interrupt enable byte | `0` | `src/bus.rs` |
+| 未使用・未マップ領域の read | `0xFF` | `src/bus.rs` |
+| ROM-only cartridge write | 無視 | `src/cartridge.rs` |
+
+## 環境別 override
+
+development、staging、production、test 専用のアプリケーション設定ファイルはありません。`.env`、`.env.example`、`.env.development`、`.env.production`、Docker、deployment platform 用設定もありません。
+
+CI の挙動は `.github/workflows/` 配下の YAML で管理されています。

--- a/docs/ja/CONTRIBUTING.md
+++ b/docs/ja/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+<!-- generated-by: gsd-doc-writer -->
+# コントリビューション
+
+GameGirl への改善ありがとうございます。プロジェクトはまだ初期段階なので、広い subsystem を一気に変えるより、小さくテストされた変更のほうが review しやすいです。
+
+## 開発セットアップ
+
+前提条件と最初の実行は `docs/ja/GETTING-STARTED.md` を参照してください。ローカル開発コマンド、style、Pull request 前の準備は `docs/ja/DEVELOPMENT.md` を参照してください。
+
+## コーディング標準
+
+- Rust 2021 と Cargo を使います。
+- Rust code は `cargo fmt --all` で format します。
+- Pull request 前に `cargo clippy --all-targets -- -D warnings` を実行します。
+- 再利用可能な emulator logic は `src/` 配下の library module に置き、CLI 引数処理は `src/main.rs` に置きます。
+- 新しい emulator 挙動にはテストを追加します。純粋な module logic は unit test、binary behavior は `tests/` 配下の integration test を優先します。
+
+## PR ガイドライン
+
+- Pull request は 1 つの挙動、subsystem、または documentation topic に絞ります。
+- 何をなぜ変えたか説明します。
+- 実行したコマンドを記載します。特に `cargo test`、`cargo fmt --all -- --check`、`cargo clippy --all-targets -- -D warnings`。
+- 挙動を変えた場合は、テストを追加または更新します。
+- 明確なリスク削減や複雑さ削減がない限り、third-party dependency は追加しません。
+- emulator behavior の変更では、検証に使った ROM fixture や hardware reference を書きます。
+
+## Issue 報告
+
+bug や feature request は GitHub Issues を使います。
+
+bug の場合は以下を含めてください。
+
+- 再現手順。
+- 期待する挙動。
+- 実際の挙動。
+- 使った ROM path または fixture。
+- CLI や test command の出力。
+- Rust toolchain version。
+
+feature request の場合は以下を含めてください。
+
+- 関係する emulator subsystem。
+- ユーザーから見える挙動、または compatibility goal。
+- 期待挙動を明確にする test ROM、reference、既存実装。

--- a/docs/ja/DEVELOPMENT.md
+++ b/docs/ja/DEVELOPMENT.md
@@ -1,0 +1,62 @@
+<!-- generated-by: gsd-doc-writer -->
+# 開発
+
+GameGirl は Rust 2021 の Cargo project です。現在は、小さくテストしやすい emulator core module と薄い CLI wrapper を中心に開発しています。
+
+## ローカルセットアップ
+
+1. リポジトリを fork または clone します。
+2. crate を build します。
+
+   ```bash
+   cargo build
+   ```
+
+3. 変更前後にテストを実行します。
+
+   ```bash
+   cargo test
+   ```
+
+4. Pull request 前に format と lint を確認します。
+
+   ```bash
+   cargo fmt --all
+   cargo clippy --all-targets -- -D warnings
+   ```
+
+`.env`、local service、database、generated source step は不要です。
+
+## 開発コマンド
+
+| コマンド | 説明 |
+|----------|------|
+| `cargo build` | binary crate と library crate を compile します。 |
+| `cargo run -- roms/hello-world/hello-world.gb` | 同梱の hello-world ROM fixture で CLI を実行します。 |
+| `cargo test` | unit test、integration test、doc test を実行します。 |
+| `cargo test cartridge` | 名前または module path に `cartridge` を含むテストを実行します。 |
+| `cargo test bus` | 名前または module path に `bus` を含むテストを実行します。 |
+| `cargo test --test cli` | `tests/cli.rs` の CLI integration test を実行します。 |
+| `cargo fmt --all` | rustfmt で Rust code を整形します。 |
+| `cargo fmt --all -- --check` | ファイルを書き換えずに format 差分を確認します。 |
+| `cargo clippy --all-targets -- -D warnings` | 全 target に clippy を実行し、warning を error として扱います。 |
+
+## コードスタイル
+
+- Rust code は rustfmt 標準に従います。`.editorconfig` が editor の基本設定を持ち、`.github/workflows/rust.yml` は `cargo fmt --all` を実行します。
+- lint には clippy を使います。`.github/workflows/rust.yml` は `cargo clippy` を実行し、`.github/workflows/rust-clippy.yml` は SARIF analysis を実行します。
+- CLI の引数処理や表示は `src/main.rs` に置き、再利用可能な emulator logic は `src/lib.rs` から公開する module に置きます。
+- emulator の純粋な処理には小さい unit test を、binary としての振る舞いには integration test を優先します。
+- `Cargo.toml` の `[dependencies]` は現在空です。意味のあるリスク削減や複雑さ削減がない限り、依存追加は避けます。
+
+## ブランチ規約
+
+明文化された branch naming rule はまだありません。`feature/add-cpu` や `fix/rom-loading-error` のように、作業内容が分かる短い名前を使います。
+
+## PR 前の確認
+
+- Pull request は 1 つの subsystem、挙動、またはドキュメント topic に絞ります。
+- review 前に `cargo fmt --all`、`cargo clippy --all-targets -- -D warnings`、`cargo test` を実行します。
+- cartridge、bus、CPU、timer、PPU、CLI の挙動を変える場合はテストを追加・更新します。
+- 検証に使った ROM fixture や focused test を説明します。
+- `.github/workflows/rust.yml`、`.github/workflows/rust-clippy.yml`、`.github/workflows/dependency-review.yml` の CI 結果を確認します。

--- a/docs/ja/GETTING-STARTED.md
+++ b/docs/ja/GETTING-STARTED.md
@@ -1,0 +1,77 @@
+<!-- generated-by: gsd-doc-writer -->
+# Getting Started
+
+このガイドでは、GameGirl をローカルで build し、テストを実行し、現在の CLI で ROM を読み込むところまで進めます。
+
+## 前提条件
+
+- Rust と Cargo が必要です。
+- このリポジトリは厳密な Rust version を pin していません。`Cargo.toml` に `rust-version` はなく、toolchain pin ファイルもありません。
+- `.github/workflows/rust-clippy.yml` では stable Rust toolchain を入れて clippy analysis を実行します。
+- database、外部サービス、emulator frontend、環境変数設定は不要です。
+
+## インストール手順
+
+1. リポジトリを clone します。
+
+   ```bash
+   git clone https://github.com/smirror/GameGirl.git
+   ```
+
+2. プロジェクトディレクトリへ移動します。
+
+   ```bash
+   cd GameGirl
+   ```
+
+3. Rust crate を build します。
+
+   ```bash
+   cargo build
+   ```
+
+4. テストを実行します。
+
+   ```bash
+   cargo test
+   ```
+
+## 最初の実行
+
+同梱の hello-world ROM fixture を使います。
+
+```bash
+cargo run -- roms/hello-world/hello-world.gb
+```
+
+現在の CLI は、読み込んだ ROM の byte 数とヘッダー情報を表示します。
+
+```text
+Loaded ROM: 32768 bytes
+Header:
+  title:
+  cartridge_type: RomOnly (0x00)
+  rom_size: 32768 bytes (code 0x00)
+  ram_size: 0 bytes (code 0x00)
+  cgb_flag: 0x00
+  header_checksum: 0xE7
+  global_checksum: 0x021B
+  entry_point: C3 50 01 00
+```
+
+## よくあるセットアップ問題
+
+| 症状 | 原因 | 対処 |
+|------|------|------|
+| `Usage: ... <rom.gb\|rom.gbc>` | ROM パスを渡していません。 | `--` の後に `.gb` または `.gbc` ファイルを渡します。 |
+| `File must be a .gb or .gbc file` | 拡張子が未対応です。 | `.gb` / `.gbc` のファイルを使います。`.GBC` のような大文字拡張子も受け付けます。 |
+| `could not read ROM ...` | ファイルが存在しない、または読めません。 | パスと権限を確認します。 |
+| `ROM is too short ... expected at least 336 bytes` | ファイルがカートリッジヘッダー領域より短いです。 | 実 ROM または `0x150` bytes 以上の fixture を使います。 |
+| `unsupported cartridge type ...` | ROM が未対応のカートリッジ種別です。 | 現時点では ROM-only カートリッジを使います。 |
+
+## 次に読むもの
+
+- `docs/ja/ARCHITECTURE.md`: モジュール構成とデータフロー。
+- `docs/ja/DEVELOPMENT.md`: 開発コマンドと作業前後の確認。
+- `docs/ja/TESTING.md`: テストコマンドと CI。
+- `docs/ja/CONFIGURATION.md`: 実行時入力と設定ファイル。

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -1,0 +1,22 @@
+<!-- generated-by: gsd-doc-writer -->
+# GameGirl 日本語ドキュメント
+
+このディレクトリには、GameGirl の主要ドキュメントの日本語版を置いています。英語版は `docs/` 直下と `CONTRIBUTING.md` に残し、日本語で確認したいときはこちらを参照します。
+
+## ドキュメント一覧
+
+| ファイル | 内容 |
+|----------|------|
+| `docs/ja/ARCHITECTURE.md` | 現在のモジュール構成、データフロー、主要な抽象化 |
+| `docs/ja/CONFIGURATION.md` | 実行時入力、Cargo/GitHub Actions などの設定 |
+| `docs/ja/GETTING-STARTED.md` | セットアップ、最初の実行、よくあるエラー |
+| `docs/ja/DEVELOPMENT.md` | 開発コマンド、コードスタイル、PR 前の確認 |
+| `docs/ja/TESTING.md` | テストの種類、実行コマンド、CI との関係 |
+| `docs/ja/CONTRIBUTING.md` | コントリビューション手順 |
+
+## 既存の日本語メモ
+
+既存の調査・実装メモも日本語で書かれています。
+
+- `docs/hot_to_proceed.md`
+- `docs/gameboy_architecture_summary.md`

--- a/docs/ja/TESTING.md
+++ b/docs/ja/TESTING.md
@@ -1,0 +1,75 @@
+<!-- generated-by: gsd-doc-writer -->
+# テスト
+
+GameGirl は Cargo 標準の Rust test harness を使います。現在のテストは、カートリッジ解析と ROM-only 挙動、Bus address routing、CLI binary の振る舞いを確認します。
+
+## テストフレームワークとセットアップ
+
+- テストフレームワークは Cargo 標準の Rust test harness です。
+- unit test は実装ファイル横の `src/cartridge.rs` と `src/bus.rs` にあります。
+- CLI integration test は `tests/cli.rs` にあります。
+- `Cargo.toml` に third-party test framework は設定されていません。
+- global setup file は不要です。
+
+## テスト実行
+
+すべて実行:
+
+```bash
+cargo test
+```
+
+cartridge に絞って実行:
+
+```bash
+cargo test cartridge
+```
+
+Bus に絞って実行:
+
+```bash
+cargo test bus
+```
+
+CLI integration test だけ実行:
+
+```bash
+cargo test --test cli
+```
+
+format と lint:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets -- -D warnings
+```
+
+## 新しいテストを書くとき
+
+- pure module のテストは同じ source file の `#[cfg(test)] mod tests` に置きます。
+- binary としての振る舞いは `tests/` 配下の integration test に置きます。
+- `rejects_rom_shorter_than_header` や `reports_missing_rom_file` のように、何を確認しているか分かる snake_case 名にします。
+- 可能な限り fixture は小さく保ちます。`tests/cli.rs` は巨大な外部 fixture ではなく、テスト内で temporary ROM bytes を作ります。
+- `roms/` 配下の ROM suite は、対象の emulator 機能が実装済みで、結果が意味を持つ段階で使います。
+
+現在の例:
+
+| 領域 | ファイル | カバー範囲 |
+|------|----------|------------|
+| Cartridge validation と metadata | `src/cartridge.rs` | ヘッダー長、タイトル解析、ROM/RAM size code、未対応 type code、ROM-only read/write。 |
+| Bus routing | `src/bus.rs` | ROM delegation、WRAM/Echo RAM mirror、OAM、I/O、HRAM、IE、未使用領域、未マップ領域。 |
+| CLI behavior | `tests/cli.rs` | valid ROM load、`.GBC` 拡張子、引数なし、不正拡張子、missing file、短すぎる ROM、未対応 cartridge type でも header を表示すること。 |
+
+## Coverage 要件
+
+coverage threshold は設定されていません。`tarpaulin`、`llvm-cov`、`grcov`、coverage 設定ファイルもありません。
+
+## CI 連携
+
+| Workflow | Trigger | テスト関連の挙動 |
+|----------|---------|------------------|
+| `.github/workflows/rust.yml` | `main` への push / pull request で `src/` 配下の Rust source が変わったとき | `cargo fmt --all`、`cargo clippy`、`cargo test --verbose` を実行します。 |
+| `.github/workflows/rust-clippy.yml` | push、pull request、月次 schedule | stable Rust toolchain と clippy を入れ、SARIF 結果を upload します。 |
+| `.github/workflows/dependency-review.yml` | `main` への pull request | `actions/dependency-review-action@v4` を実行します。 |
+
+`roms/blargg-gb-tests/`、`roms/mooneye/`、`roms/hello-world/` は将来の emulator validation 用に同梱されています。ただし、多くの ROM はまだ自動テストには接続されていません。

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -1,12 +1,16 @@
 use crate::cartridge::Cartridge;
 
-#[allow(dead_code)]
+const WRAM_SIZE: usize = 0x2000;
+const OAM_SIZE: usize = 0xA0;
+const IO_SIZE: usize = 0x80;
+const HRAM_SIZE: usize = 0x7F;
+
 pub struct Bus {
     cartridge: Cartridge,
-    wram: [u8; 0x2000],
-    oam: [u8; 0xA0],
-    io: [u8; 0x80],
-    hram: [u8; 0x7F],
+    wram: [u8; WRAM_SIZE],
+    oam: [u8; OAM_SIZE],
+    io_registers: [u8; IO_SIZE],
+    hram: [u8; HRAM_SIZE],
     interrupt_enable: u8,
 }
 
@@ -14,17 +18,113 @@ impl Bus {
     pub fn new(cartridge: Cartridge) -> Self {
         Self {
             cartridge,
-            wram: [0; 0x2000],
-            oam: [0; 0xA0],
-            io: [0; 0x80],
-            hram: [0; 0x7F],
+            wram: [0; WRAM_SIZE],
+            oam: [0; OAM_SIZE],
+            io_registers: [0; IO_SIZE],
+            hram: [0; HRAM_SIZE],
             interrupt_enable: 0,
         }
     }
 
-    pub fn read8(&self, _addr: u16) -> u8 {
-        0xFF
+    pub fn read8(&self, addr: u16) -> u8 {
+        match addr {
+            0x0000..=0x7FFF => self.cartridge.read_rom(addr),
+            0xC000..=0xDFFF => self.wram[wram_index(addr)],
+            0xE000..=0xFDFF => self.wram[echo_wram_index(addr)],
+            0xFE00..=0xFE9F => self.oam[oam_index(addr)],
+            0xFEA0..=0xFEFF => 0xFF,
+            0xFF00..=0xFF7F => self.io_registers[io_index(addr)],
+            0xFF80..=0xFFFE => self.hram[hram_index(addr)],
+            0xFFFF => self.interrupt_enable,
+            _ => 0xFF,
+        }
     }
 
-    pub fn write8(&mut self, _addr: u16, _value: u8) {}
+    pub fn write8(&mut self, addr: u16, value: u8) {
+        match addr {
+            0x0000..=0x7FFF => self.cartridge.write_rom(addr, value),
+            0xC000..=0xDFFF => self.wram[wram_index(addr)] = value,
+            0xE000..=0xFDFF => self.wram[echo_wram_index(addr)] = value,
+            0xFE00..=0xFE9F => self.oam[oam_index(addr)] = value,
+            0xFEA0..=0xFEFF => {}
+            0xFF00..=0xFF7F => self.io_registers[io_index(addr)] = value,
+            0xFF80..=0xFFFE => self.hram[hram_index(addr)] = value,
+            0xFFFF => self.interrupt_enable = value,
+            _ => {}
+        }
+    }
+}
+
+fn wram_index(addr: u16) -> usize {
+    usize::from(addr - 0xC000)
+}
+
+fn echo_wram_index(addr: u16) -> usize {
+    usize::from(addr - 0xE000) % WRAM_SIZE
+}
+
+fn oam_index(addr: u16) -> usize {
+    usize::from(addr - 0xFE00)
+}
+
+fn io_index(addr: u16) -> usize {
+    usize::from(addr - 0xFF00)
+}
+
+fn hram_index(addr: u16) -> usize {
+    usize::from(addr - 0xFF80)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn bus() -> Bus {
+        let mut rom = vec![0; 0x8000];
+        rom[0x0000] = 0xAA;
+        rom[0x7FFF] = 0xBB;
+        Bus::new(Cartridge::from_bytes(rom).expect("valid ROM-only cartridge"))
+    }
+
+    #[test]
+    fn delegates_rom_reads_and_writes_to_cartridge() {
+        let mut bus = bus();
+
+        assert_eq!(bus.read8(0x0000), 0xAA);
+        bus.write8(0x0000, 0x99);
+        assert_eq!(bus.read8(0x0000), 0xAA);
+    }
+
+    #[test]
+    fn mirrors_wram_and_echo_ram() {
+        let mut bus = bus();
+
+        bus.write8(0xC000, 0x12);
+        assert_eq!(bus.read8(0xE000), 0x12);
+
+        bus.write8(0xE000, 0x34);
+        assert_eq!(bus.read8(0xC000), 0x34);
+    }
+
+    #[test]
+    fn unusable_range_reads_ff_and_ignores_writes() {
+        let mut bus = bus();
+
+        bus.write8(0xFEA0, 0x12);
+
+        assert_eq!(bus.read8(0xFEA0), 0xFF);
+    }
+
+    #[test]
+    fn io_hram_and_ie_are_writable() {
+        let mut bus = bus();
+
+        bus.write8(0xFF00, 0x12);
+        bus.write8(0xFF80, 0x34);
+        bus.write8(0xFFFF, 0x56);
+
+        assert_eq!(bus.read8(0xFF00), 0x12);
+        assert_eq!(bus.read8(0xFF80), 0x34);
+        assert_eq!(bus.read8(0xFFFF), 0x56);
+    }
 }

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -91,6 +91,7 @@ mod tests {
         let mut bus = bus();
 
         assert_eq!(bus.read8(0x0000), 0xAA);
+        assert_eq!(bus.read8(0x7FFF), 0xBB);
         bus.write8(0x0000, 0x99);
         assert_eq!(bus.read8(0x0000), 0xAA);
     }
@@ -111,8 +112,21 @@ mod tests {
         let mut bus = bus();
 
         bus.write8(0xFEA0, 0x12);
+        bus.write8(0xFEFF, 0x34);
 
         assert_eq!(bus.read8(0xFEA0), 0xFF);
+        assert_eq!(bus.read8(0xFEFF), 0xFF);
+    }
+
+    #[test]
+    fn oam_placeholder_range_is_writable() {
+        let mut bus = bus();
+
+        bus.write8(0xFE00, 0x12);
+        bus.write8(0xFE9F, 0x34);
+
+        assert_eq!(bus.read8(0xFE00), 0x12);
+        assert_eq!(bus.read8(0xFE9F), 0x34);
     }
 
     #[test]
@@ -126,5 +140,16 @@ mod tests {
         assert_eq!(bus.read8(0xFF00), 0x12);
         assert_eq!(bus.read8(0xFF80), 0x34);
         assert_eq!(bus.read8(0xFFFF), 0x56);
+    }
+
+    #[test]
+    fn unmapped_ranges_read_ff_and_ignore_writes() {
+        let mut bus = bus();
+
+        bus.write8(0x8000, 0x12);
+        bus.write8(0xA000, 0x34);
+
+        assert_eq!(bus.read8(0x8000), 0xFF);
+        assert_eq!(bus.read8(0xA000), 0xFF);
     }
 }

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -1,0 +1,30 @@
+use crate::cartridge::Cartridge;
+
+#[allow(dead_code)]
+pub struct Bus {
+    cartridge: Cartridge,
+    wram: [u8; 0x2000],
+    oam: [u8; 0xA0],
+    io: [u8; 0x80],
+    hram: [u8; 0x7F],
+    interrupt_enable: u8,
+}
+
+impl Bus {
+    pub fn new(cartridge: Cartridge) -> Self {
+        Self {
+            cartridge,
+            wram: [0; 0x2000],
+            oam: [0; 0xA0],
+            io: [0; 0x80],
+            hram: [0; 0x7F],
+            interrupt_enable: 0,
+        }
+    }
+
+    pub fn read8(&self, _addr: u16) -> u8 {
+        0xFF
+    }
+
+    pub fn write8(&mut self, _addr: u16, _value: u8) {}
+}

--- a/src/cartridge.rs
+++ b/src/cartridge.rs
@@ -1,7 +1,89 @@
 use std::io;
+use std::ops::Range;
 use std::path::{Path, PathBuf};
 
 pub const MIN_CARTRIDGE_HEADER_LEN: usize = 0x150;
+const ENTRY_POINT_RANGE: Range<usize> = 0x0100..0x0104;
+const LOGO_RANGE: Range<usize> = 0x0104..0x0134;
+const TITLE_RANGE: Range<usize> = 0x0134..0x0144;
+const HEADER_RANGE: Range<usize> = 0x0100..0x0150;
+const CGB_FLAG_OFFSET: usize = 0x0143;
+const CARTRIDGE_TYPE_OFFSET: usize = 0x0147;
+const ROM_SIZE_OFFSET: usize = 0x0148;
+const RAM_SIZE_OFFSET: usize = 0x0149;
+const HEADER_CHECKSUM_OFFSET: usize = 0x014D;
+const GLOBAL_CHECKSUM_RANGE: Range<usize> = 0x014E..0x0150;
+
+#[derive(Debug)]
+pub struct Cartridge {
+    rom: Vec<u8>,
+    pub header: CartridgeHeader,
+}
+
+impl Cartridge {
+    pub fn rom_len(&self) -> usize {
+        self.rom.len()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CartridgeHeader {
+    pub title: String,
+    pub cartridge_type: CartridgeType,
+    pub cartridge_type_code: u8,
+    pub rom_size: usize,
+    pub rom_size_code: u8,
+    pub ram_size: usize,
+    pub ram_size_code: u8,
+    pub entry_point: [u8; 4],
+    pub logo: [u8; 0x30],
+    pub header_bytes: [u8; 0x50],
+    pub cgb_flag: u8,
+    pub header_checksum: u8,
+    pub global_checksum: u16,
+}
+
+impl CartridgeHeader {
+    pub fn parse(bytes: &[u8]) -> Result<Self, CartridgeError> {
+        validate_rom_bytes(bytes)?;
+
+        let cartridge_type_code = bytes[CARTRIDGE_TYPE_OFFSET];
+        let rom_size_code = bytes[ROM_SIZE_OFFSET];
+        let ram_size_code = bytes[RAM_SIZE_OFFSET];
+        let global_checksum = u16::from_be_bytes(slice_to_array(bytes, GLOBAL_CHECKSUM_RANGE));
+
+        Ok(Self {
+            title: parse_title(bytes),
+            cartridge_type: CartridgeType::from_code(cartridge_type_code),
+            cartridge_type_code,
+            rom_size: rom_size_from_code(rom_size_code)?,
+            rom_size_code,
+            ram_size: ram_size_from_code(ram_size_code)?,
+            ram_size_code,
+            entry_point: slice_to_array(bytes, ENTRY_POINT_RANGE),
+            logo: slice_to_array(bytes, LOGO_RANGE),
+            header_bytes: slice_to_array(bytes, HEADER_RANGE),
+            cgb_flag: bytes[CGB_FLAG_OFFSET],
+            header_checksum: bytes[HEADER_CHECKSUM_OFFSET],
+            global_checksum,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CartridgeType {
+    RomOnly,
+    Unsupported(u8),
+}
+
+impl CartridgeType {
+    fn from_code(code: u8) -> Self {
+        match code {
+            0x00 => Self::RomOnly,
+            other => Self::Unsupported(other),
+        }
+    }
+}
 
 #[derive(Debug)]
 pub enum CartridgeError {
@@ -46,6 +128,49 @@ pub fn validate_rom_bytes(bytes: &[u8]) -> Result<(), CartridgeError> {
     }
 
     Ok(())
+}
+
+fn parse_title(bytes: &[u8]) -> String {
+    let title_bytes = &bytes[TITLE_RANGE];
+    let title_len = title_bytes
+        .iter()
+        .position(|byte| *byte == 0)
+        .unwrap_or(title_bytes.len());
+
+    String::from_utf8_lossy(&title_bytes[..title_len]).to_string()
+}
+
+fn rom_size_from_code(code: u8) -> Result<usize, CartridgeError> {
+    match code {
+        0x00 => Ok(32 * 1024),
+        0x01 => Ok(64 * 1024),
+        0x02 => Ok(128 * 1024),
+        0x03 => Ok(256 * 1024),
+        0x04 => Ok(512 * 1024),
+        0x05 => Ok(1024 * 1024),
+        0x06 => Ok(2 * 1024 * 1024),
+        0x07 => Ok(4 * 1024 * 1024),
+        0x08 => Ok(8 * 1024 * 1024),
+        other => Err(CartridgeError::UnsupportedRomSize(other)),
+    }
+}
+
+fn ram_size_from_code(code: u8) -> Result<usize, CartridgeError> {
+    match code {
+        0x00 => Ok(0),
+        0x01 => Ok(2 * 1024),
+        0x02 => Ok(8 * 1024),
+        0x03 => Ok(32 * 1024),
+        0x04 => Ok(128 * 1024),
+        0x05 => Ok(64 * 1024),
+        other => Err(CartridgeError::UnsupportedRamSize(other)),
+    }
+}
+
+fn slice_to_array<const N: usize>(bytes: &[u8], range: Range<usize>) -> [u8; N] {
+    bytes[range]
+        .try_into()
+        .expect("header range length mismatch")
 }
 
 pub fn load_rom_file(path: impl AsRef<Path>) -> Result<Vec<u8>, CartridgeError> {

--- a/src/cartridge.rs
+++ b/src/cartridge.rs
@@ -1,0 +1,60 @@
+use std::io;
+use std::path::{Path, PathBuf};
+
+pub const MIN_CARTRIDGE_HEADER_LEN: usize = 0x150;
+
+#[derive(Debug)]
+pub enum CartridgeError {
+    Io { path: PathBuf, source: io::Error },
+    TooShort { len: usize },
+    UnsupportedCartridgeType(u8),
+    UnsupportedRomSize(u8),
+    UnsupportedRamSize(u8),
+}
+
+impl std::fmt::Display for CartridgeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io { path, source } => {
+                write!(f, "could not read ROM '{}': {source}", path.display())
+            }
+            Self::TooShort { len } => write!(
+                f,
+                "ROM is too short: {len} bytes read, expected at least {MIN_CARTRIDGE_HEADER_LEN} bytes"
+            ),
+            Self::UnsupportedCartridgeType(code) => {
+                write!(f, "unsupported cartridge type: 0x{code:02X}")
+            }
+            Self::UnsupportedRomSize(code) => write!(f, "unsupported ROM size code: 0x{code:02X}"),
+            Self::UnsupportedRamSize(code) => write!(f, "unsupported RAM size code: 0x{code:02X}"),
+        }
+    }
+}
+
+impl std::error::Error for CartridgeError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Io { source, .. } => Some(source),
+            _ => None,
+        }
+    }
+}
+
+pub fn validate_rom_bytes(bytes: &[u8]) -> Result<(), CartridgeError> {
+    if bytes.len() < MIN_CARTRIDGE_HEADER_LEN {
+        return Err(CartridgeError::TooShort { len: bytes.len() });
+    }
+
+    Ok(())
+}
+
+pub fn load_rom_file(path: impl AsRef<Path>) -> Result<Vec<u8>, CartridgeError> {
+    let path = path.as_ref();
+    let bytes = std::fs::read(path).map_err(|source| CartridgeError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+
+    validate_rom_bytes(&bytes)?;
+    Ok(bytes)
+}

--- a/src/cartridge.rs
+++ b/src/cartridge.rs
@@ -58,3 +58,42 @@ pub fn load_rom_file(path: impl AsRef<Path>) -> Result<Vec<u8>, CartridgeError> 
     validate_rom_bytes(&bytes)?;
     Ok(bytes)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rom_bytes() -> Vec<u8> {
+        vec![0; MIN_CARTRIDGE_HEADER_LEN]
+    }
+
+    #[test]
+    fn rejects_rom_shorter_than_header() {
+        let bytes = vec![0; MIN_CARTRIDGE_HEADER_LEN - 1];
+        let result = validate_rom_bytes(&bytes);
+
+        match result {
+            Err(CartridgeError::TooShort { len }) => {
+                assert_eq!(len, MIN_CARTRIDGE_HEADER_LEN - 1);
+            }
+            other => panic!("expected too-short error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn accepts_rom_with_complete_header_region() {
+        let bytes = rom_bytes();
+
+        assert!(validate_rom_bytes(&bytes).is_ok());
+    }
+
+    #[test]
+    fn too_short_error_display_is_human_readable() {
+        let error = CartridgeError::TooShort { len: 3 };
+
+        assert_eq!(
+            error.to_string(),
+            "ROM is too short: 3 bytes read, expected at least 336 bytes"
+        );
+    }
+}

--- a/src/cartridge.rs
+++ b/src/cartridge.rs
@@ -34,6 +34,20 @@ impl Cartridge {
     pub fn rom_len(&self) -> usize {
         self.rom.len()
     }
+
+    pub fn read_rom(&self, address: u16) -> u8 {
+        let address = usize::from(address);
+
+        if address > 0x7FFF {
+            return 0xFF;
+        }
+
+        self.rom.get(address).copied().unwrap_or(0xFF)
+    }
+
+    pub fn write_rom(&mut self, _address: u16, _value: u8) {
+        // ROM-only cartridges do not mutate ROM bytes on writes.
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -212,6 +226,10 @@ mod tests {
         vec![0; MIN_CARTRIDGE_HEADER_LEN]
     }
 
+    fn full_rom_bytes() -> Vec<u8> {
+        vec![0; 0x8000]
+    }
+
     #[test]
     fn rejects_rom_shorter_than_header() {
         let bytes = vec![0; MIN_CARTRIDGE_HEADER_LEN - 1];
@@ -283,5 +301,58 @@ mod tests {
             Err(CartridgeError::UnsupportedRamSize(0xFF)) => {}
             other => panic!("expected unsupported RAM size, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn parses_header_title_entry_and_size_metadata() {
+        let mut bytes = rom_bytes();
+        bytes[ENTRY_POINT_RANGE].copy_from_slice(&[0x00, 0xC3, 0x50, 0x01]);
+        bytes[0x0134..0x013C].copy_from_slice(b"GAMEGIRL");
+        bytes[ROM_SIZE_OFFSET] = 0x02;
+        bytes[RAM_SIZE_OFFSET] = 0x03;
+        bytes[HEADER_CHECKSUM_OFFSET] = 0x42;
+        bytes[GLOBAL_CHECKSUM_RANGE].copy_from_slice(&[0x12, 0x34]);
+
+        let cartridge = Cartridge::from_bytes(bytes).expect("valid ROM-only cartridge");
+
+        assert_eq!(cartridge.header.title, "GAMEGIRL");
+        assert_eq!(cartridge.header.cartridge_type, CartridgeType::RomOnly);
+        assert_eq!(cartridge.header.cartridge_type_code, 0x00);
+        assert_eq!(cartridge.header.rom_size_code, 0x02);
+        assert_eq!(cartridge.header.rom_size, 128 * 1024);
+        assert_eq!(cartridge.header.ram_size_code, 0x03);
+        assert_eq!(cartridge.header.ram_size, 32 * 1024);
+        assert_eq!(cartridge.header.entry_point, [0x00, 0xC3, 0x50, 0x01]);
+        assert_eq!(cartridge.header.header_checksum, 0x42);
+        assert_eq!(cartridge.header.global_checksum, 0x1234);
+    }
+
+    #[test]
+    fn rom_only_reads_fixed_rom_range() {
+        let mut bytes = full_rom_bytes();
+        bytes[0x0000] = 0xAA;
+        bytes[0x7FFF] = 0xBB;
+        let cartridge = Cartridge::from_bytes(bytes).expect("valid ROM-only cartridge");
+
+        assert_eq!(cartridge.read_rom(0x0000), 0xAA);
+        assert_eq!(cartridge.read_rom(0x7FFF), 0xBB);
+    }
+
+    #[test]
+    fn rom_only_reads_missing_fixture_bytes_as_ff() {
+        let cartridge = Cartridge::from_bytes(rom_bytes()).expect("valid ROM-only cartridge");
+
+        assert_eq!(cartridge.read_rom(0x4000), 0xFF);
+    }
+
+    #[test]
+    fn rom_only_writes_do_not_mutate_rom() {
+        let mut bytes = full_rom_bytes();
+        bytes[0x0000] = 0xAA;
+        let mut cartridge = Cartridge::from_bytes(bytes).expect("valid ROM-only cartridge");
+
+        cartridge.write_rom(0x0000, 0x99);
+
+        assert_eq!(cartridge.read_rom(0x0000), 0xAA);
     }
 }

--- a/src/cartridge.rs
+++ b/src/cartridge.rs
@@ -21,6 +21,16 @@ pub struct Cartridge {
 }
 
 impl Cartridge {
+    pub fn from_bytes(bytes: Vec<u8>) -> Result<Self, CartridgeError> {
+        let header = CartridgeHeader::parse(&bytes)?;
+
+        if let CartridgeType::Unsupported(code) = header.cartridge_type {
+            return Err(CartridgeError::UnsupportedCartridgeType(code));
+        }
+
+        Ok(Self { rom: bytes, header })
+    }
+
     pub fn rom_len(&self) -> usize {
         self.rom.len()
     }
@@ -180,8 +190,18 @@ pub fn load_rom_file(path: impl AsRef<Path>) -> Result<Vec<u8>, CartridgeError> 
         source,
     })?;
 
-    validate_rom_bytes(&bytes)?;
+    Cartridge::from_bytes(bytes.clone())?;
     Ok(bytes)
+}
+
+pub fn load_cartridge_file(path: impl AsRef<Path>) -> Result<Cartridge, CartridgeError> {
+    let path = path.as_ref();
+    let bytes = std::fs::read(path).map_err(|source| CartridgeError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+
+    Cartridge::from_bytes(bytes)
 }
 
 #[cfg(test)]
@@ -220,5 +240,48 @@ mod tests {
             error.to_string(),
             "ROM is too short: 3 bytes read, expected at least 336 bytes"
         );
+    }
+
+    #[test]
+    fn constructs_rom_only_cartridge() {
+        let cartridge = Cartridge::from_bytes(rom_bytes()).expect("valid ROM-only cartridge");
+
+        assert_eq!(cartridge.header.cartridge_type, CartridgeType::RomOnly);
+        assert_eq!(cartridge.header.rom_size, 32 * 1024);
+        assert_eq!(cartridge.header.ram_size, 0);
+        assert_eq!(cartridge.rom_len(), MIN_CARTRIDGE_HEADER_LEN);
+    }
+
+    #[test]
+    fn rejects_unsupported_cartridge_type() {
+        let mut bytes = rom_bytes();
+        bytes[CARTRIDGE_TYPE_OFFSET] = 0x01;
+
+        match Cartridge::from_bytes(bytes) {
+            Err(CartridgeError::UnsupportedCartridgeType(0x01)) => {}
+            other => panic!("expected unsupported cartridge type, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_unsupported_rom_size_code() {
+        let mut bytes = rom_bytes();
+        bytes[ROM_SIZE_OFFSET] = 0xFF;
+
+        match Cartridge::from_bytes(bytes) {
+            Err(CartridgeError::UnsupportedRomSize(0xFF)) => {}
+            other => panic!("expected unsupported ROM size, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_unsupported_ram_size_code() {
+        let mut bytes = rom_bytes();
+        bytes[RAM_SIZE_OFFSET] = 0xFF;
+
+        match Cartridge::from_bytes(bytes) {
+            Err(CartridgeError::UnsupportedRamSize(0xFF)) => {}
+            other => panic!("expected unsupported RAM size, got {other:?}"),
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod cartridge;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,2 @@
+pub mod bus;
 pub mod cartridge;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,8 @@ use std::env;
 use std::path::Path;
 use std::process::ExitCode;
 
+use game_girl::cartridge::{Cartridge, CartridgeHeader};
+
 fn main() -> ExitCode {
     let mut args = env::args();
     let program = args.next().unwrap_or_else(|| "game_girl".to_string());
@@ -16,11 +18,29 @@ fn main() -> ExitCode {
         return ExitCode::FAILURE;
     }
 
-    match game_girl::cartridge::load_rom_file(&file_path) {
+    let bytes = match std::fs::read(&file_path) {
         Ok(bytes) => {
             println!("Loaded ROM: {} bytes", bytes.len());
-            ExitCode::SUCCESS
+            bytes
         }
+        Err(error) => {
+            eprintln!("could not read ROM '{file_path}': {error}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let header = match CartridgeHeader::parse(&bytes) {
+        Ok(header) => header,
+        Err(error) => {
+            eprintln!("{error}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    print_header(&header);
+
+    match Cartridge::from_bytes(bytes) {
+        Ok(_) => ExitCode::SUCCESS,
         Err(error) => {
             eprintln!("{error}");
             ExitCode::FAILURE
@@ -35,4 +55,33 @@ fn is_supported_rom_path(path: impl AsRef<Path>) -> bool {
         .is_some_and(|extension| {
             extension.eq_ignore_ascii_case("gb") || extension.eq_ignore_ascii_case("gbc")
         })
+}
+
+fn print_header(header: &CartridgeHeader) {
+    println!("Header:");
+    println!("  title: {}", header.title);
+    println!(
+        "  cartridge_type: {:?} (0x{:02X})",
+        header.cartridge_type, header.cartridge_type_code
+    );
+    println!(
+        "  rom_size: {} bytes (code 0x{:02X})",
+        header.rom_size, header.rom_size_code
+    );
+    println!(
+        "  ram_size: {} bytes (code 0x{:02X})",
+        header.ram_size, header.ram_size_code
+    );
+    println!("  cgb_flag: 0x{:02X}", header.cgb_flag);
+    println!("  header_checksum: 0x{:02X}", header.header_checksum);
+    println!("  global_checksum: 0x{:04X}", header.global_checksum);
+    println!("  entry_point: {}", format_bytes(&header.entry_point));
+}
+
+fn format_bytes(bytes: &[u8]) -> String {
+    bytes
+        .iter()
+        .map(|byte| format!("{byte:02X}"))
+        .collect::<Vec<_>>()
+        .join(" ")
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,22 +1,38 @@
 use std::env;
-use std::fs;
+use std::path::Path;
+use std::process::ExitCode;
 
-fn main() {
-    let args: Vec<String> = env::args().collect();
+fn main() -> ExitCode {
+    let mut args = env::args();
+    let program = args.next().unwrap_or_else(|| "game_girl".to_string());
 
-    if args.len() < 2 {
-        eprintln!("Usage: {} <rom.gb|rom.gbc>", args[0]);
-        return;
+    let Some(file_path) = args.next() else {
+        eprintln!("Usage: {program} <rom.gb|rom.gbc>");
+        return ExitCode::FAILURE;
+    };
+
+    if !is_supported_rom_path(&file_path) {
+        eprintln!("File must be a .gb or .gbc file");
+        return ExitCode::FAILURE;
     }
 
-    let file_path = &args[1];
-
-    if !file_path.ends_with(".gb") && !file_path.ends_with(".gbc") {
-        println!("File must be a .gb or .gbc file");
-        return;
+    match game_girl::cartridge::load_rom_file(&file_path) {
+        Ok(bytes) => {
+            println!("Loaded ROM: {} bytes", bytes.len());
+            ExitCode::SUCCESS
+        }
+        Err(error) => {
+            eprintln!("{error}");
+            ExitCode::FAILURE
+        }
     }
+}
 
-    let contents = fs::read_to_string(file_path)
-        .expect("Something went wrong reading the file");
-    println!("with text:\n{}", contents);
+fn is_supported_rom_path(path: impl AsRef<Path>) -> bool {
+    path.as_ref()
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| {
+            extension.eq_ignore_ascii_case("gb") || extension.eq_ignore_ascii_case("gbc")
+        })
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,0 +1,138 @@
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn cli_path() -> &'static str {
+    env!("CARGO_BIN_EXE_game_girl")
+}
+
+fn temp_path(file_name: &str) -> PathBuf {
+    let suffix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be after unix epoch")
+        .as_nanos();
+
+    std::env::temp_dir().join(format!(
+        "game_girl_cli_{}_{}_{}",
+        std::process::id(),
+        suffix,
+        file_name
+    ))
+}
+
+fn rom_only_bytes() -> Vec<u8> {
+    let mut bytes = vec![0; 0x8000];
+    bytes[0x0134..0x0138].copy_from_slice(b"TEST");
+    bytes[0x0147] = 0x00;
+    bytes[0x0148] = 0x00;
+    bytes[0x0149] = 0x00;
+    bytes
+}
+
+#[test]
+fn loads_valid_gb_rom() {
+    let path = temp_path("valid.gb");
+    fs::write(&path, rom_only_bytes()).expect("test ROM should be writable");
+
+    let output = Command::new(cli_path())
+        .arg(&path)
+        .output()
+        .expect("CLI should run");
+
+    fs::remove_file(&path).ok();
+
+    assert!(
+        output.status.success(),
+        "expected success, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "Loaded ROM: 32768 bytes"
+    );
+}
+
+#[test]
+fn accepts_case_insensitive_gbc_extension() {
+    let path = temp_path("valid.GBC");
+    fs::write(&path, rom_only_bytes()).expect("test ROM should be writable");
+
+    let output = Command::new(cli_path())
+        .arg(&path)
+        .output()
+        .expect("CLI should run");
+
+    fs::remove_file(&path).ok();
+
+    assert!(
+        output.status.success(),
+        "expected success, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn rejects_missing_argument_with_usage() {
+    let output = Command::new(cli_path()).output().expect("CLI should run");
+
+    assert!(!output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("Usage:"),
+        "stderr should include usage, got: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn rejects_non_rom_extension_before_reading_file() {
+    let output = Command::new(cli_path())
+        .arg("notes.txt")
+        .output()
+        .expect("CLI should run");
+
+    assert!(!output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("File must be a .gb or .gbc file"),
+        "stderr should explain supported extensions, got: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn reports_missing_rom_file() {
+    let path = temp_path("missing.gb");
+
+    let output = Command::new(cli_path())
+        .arg(&path)
+        .output()
+        .expect("CLI should run");
+
+    assert!(!output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("could not read ROM"),
+        "stderr should explain read failure, got: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn reports_too_short_rom_file() {
+    let path = temp_path("too-short.gb");
+    fs::write(&path, [0x01, 0x02, 0x03]).expect("test ROM should be writable");
+
+    let output = Command::new(cli_path())
+        .arg(&path)
+        .output()
+        .expect("CLI should run");
+
+    fs::remove_file(&path).ok();
+
+    assert!(!output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("ROM is too short: 3 bytes read, expected at least 336 bytes"),
+        "stderr should explain header length failure, got: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -47,9 +47,39 @@ fn loads_valid_gb_rom() {
         "expected success, stderr: {}",
         String::from_utf8_lossy(&output.stderr)
     );
-    assert_eq!(
-        String::from_utf8_lossy(&output.stdout).trim(),
-        "Loaded ROM: 32768 bytes"
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Loaded ROM: 32768 bytes"));
+    assert!(stdout.contains("Header:"));
+    assert!(stdout.contains("title: TEST"));
+    assert!(stdout.contains("cartridge_type: RomOnly (0x00)"));
+    assert!(stdout.contains("rom_size: 32768 bytes (code 0x00)"));
+    assert!(stdout.contains("ram_size: 0 bytes (code 0x00)"));
+}
+
+#[test]
+fn prints_header_before_rejecting_unsupported_cartridge_type() {
+    let path = temp_path("unsupported.gb");
+    let mut bytes = rom_only_bytes();
+    bytes[0x0147] = 0x01;
+    fs::write(&path, bytes).expect("test ROM should be writable");
+
+    let output = Command::new(cli_path())
+        .arg(&path)
+        .output()
+        .expect("CLI should run");
+
+    fs::remove_file(&path).ok();
+
+    assert!(!output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("cartridge_type: Unsupported(1) (0x01)"),
+        "stdout should include parsed header, got: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("unsupported cartridge type: 0x01"),
+        "stderr should explain unsupported type, got: {}",
+        String::from_utf8_lossy(&output.stderr)
     );
 }
 


### PR DESCRIPTION
## Summary
- ROM を UTF-8 前提の読み込みからバイナリ読み込みへ切り替え
- `cartridge` / `bus` モジュールを追加し、ROM header 解析と DMG メモリルーティングを実装
- CLI の挙動を統合テストでカバーし、Phase 1 の完了検証を `.planning` に反映
- 既存の調査・計画・レビュー資料を更新して、Phase 2 へ進める状態に整理

## Testing
- `cargo test` を実行し、単体テスト 17 本と CLI 統合テスト 6 本が通過
- `cargo clippy --all-targets -- -D warnings` が通過
- 追加した CLI テストで、有効 ROM、拡張子チェック、欠落引数、存在しないファイル、短すぎる ROM を検証